### PR TITLE
Use *const () instead of libc::void

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glfw"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The glfw-rs developers."]
 description = "GLFW3 bindings and idiomatic wrapper for Rust."
 keywords = ["windowing", "opengl"]
@@ -20,5 +20,5 @@ enum_primitive = "0.1"
 num = "0.1"
 
 [dependencies.glfw-sys]
-glfw-sys = "*"
+glfw-sys = "3.1"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ pub struct GammaRamp {
 }
 
 /// An OpenGL process address.
-pub type GLProc = ffi::GLFWglproc;
+pub type GLProc = *const ();
 
 /// A token from which to call various GLFW functions. It can be obtained by
 /// calling the `init` function. This cannot be sent to other tasks, and should
@@ -728,7 +728,7 @@ impl Glfw {
     pub fn get_proc_address_raw(&self, procname: &str) -> GLProc {
         debug_assert!(unsafe { ffi::glfwGetCurrentContext() } != std::ptr::null_mut());
         with_c_str(procname, |procname| {
-            unsafe { ffi::glfwGetProcAddress(procname) }
+            unsafe { ffi::glfwGetProcAddress(procname) as GLProc }
         })
     }
 


### PR DESCRIPTION
This is obviously a breaking change. Goes with https://github.com/bjz/gl-rs/pull/364 (will require a publish)