### PR TITLE
Fix linking to wrong library on Unix-like systems (#292)

### DIFF
--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -19,6 +19,12 @@ extern {}
 
 #[cfg(not(feature = "glfw-sys"))]
 // leaving off `kind = static` allows for the specification of a dynamic library if desired
+#[cfg(target_family = "unix")]
+#[link(name = "glfw")]
+extern {}
+
+#[cfg(not(feature = "glfw-sys"))]
+#[cfg(target_family = "windows")]
 #[link(name = "glfw3")]
 extern {}
 


### PR DESCRIPTION
GLFW when compiled on Unix-like systems as shared lib is named glfw, not glfw3. Fix #292.