### PR TITLE
Add support for drag and drop

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -88,5 +88,6 @@ fn handle_window_event(window: &mut glfw::Window, (time, event): (f64, glfw::Win
                 _ => {}
             }
         }
+        glfw::WindowEvent::FileDrop(paths)                => println!("Time: {:?}, Files dropped: {:?}", time, paths),
     }
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -15,9 +15,13 @@
 
 //! Private callback support functions.
 
-use libc::{c_double, c_int, c_uint};
+use libc::{c_double, c_int, c_uint, c_char};
+use std::slice;
+use std::ffi::CStr;
+use std::str;
 use std::mem;
 use std::sync::mpsc::Sender;
+use std::path::PathBuf;
 
 use super::*;
 
@@ -139,3 +143,4 @@ window_callback!(fn cursor_enter_callback(entered: c_int)                       
 window_callback!(fn scroll_callback(xpos: c_double, ypos: c_double)                         => Scroll(xpos as f64, ypos as f64));
 window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => Key(mem::transmute(key), scancode, mem::transmute(action), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn char_callback(character: c_uint)                                        => Char(::std::char::from_u32(character).unwrap()));
+window_callback!(fn drop_callback(num_paths: c_int, paths: *mut *const c_char)            => Dropped(slice::from_raw_parts(paths, num_paths as usize).iter().map(|path| PathBuf::from(str::from_utf8(CStr::from_ptr(*path).to_bytes()).unwrap().to_string())).collect()));

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -143,4 +143,4 @@ window_callback!(fn cursor_enter_callback(entered: c_int)                       
 window_callback!(fn scroll_callback(xpos: c_double, ypos: c_double)                         => Scroll(xpos as f64, ypos as f64));
 window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => Key(mem::transmute(key), scancode, mem::transmute(action), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn char_callback(character: c_uint)                                        => Char(::std::char::from_u32(character).unwrap()));
-window_callback!(fn drop_callback(num_paths: c_int, paths: *mut *const c_char)            => Dropped(slice::from_raw_parts(paths, num_paths as usize).iter().map(|path| PathBuf::from(str::from_utf8(CStr::from_ptr(*path).to_bytes()).unwrap().to_string())).collect()));
+window_callback!(fn drop_callback(num_paths: c_int, paths: *mut *const c_char)            => FileDrop(slice::from_raw_parts(paths, num_paths as usize).iter().map(|path| PathBuf::from(str::from_utf8(CStr::from_ptr(*path).to_bytes()).unwrap().to_string())).collect()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1096,7 +1096,7 @@ pub enum WindowEvent {
     Scroll(f64, f64),
     Key(Key, Scancode, Action, Modifiers),
     Char(char),
-    Dropped(Vec<PathBuf>),
+    FileDrop(Vec<PathBuf>),
 }
 
 /// Returns an iterator that yields until no more messages are contained in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use std::fmt;
 use std::marker::Send;
 use std::ptr;
 use std::slice;
+use std::path::PathBuf;
 use semver::Version;
 
 /// Alias to `MouseButton1`, supplied for improved clarity.
@@ -1080,7 +1081,7 @@ bitflags! {
 pub type Scancode = c_int;
 
 /// Window event messages.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, PartialEq, PartialOrd, Debug)]
 pub enum WindowEvent {
     Pos(i32, i32),
     Size(i32, i32),
@@ -1095,6 +1096,7 @@ pub enum WindowEvent {
     Scroll(f64, f64),
     Key(Key, Scancode, Action, Modifiers),
     Char(char),
+    Dropped(Vec<PathBuf>),
 }
 
 /// Returns an iterator that yields until no more messages are contained in the
@@ -1378,6 +1380,7 @@ impl Window {
         self.set_cursor_pos_polling(should_poll);
         self.set_cursor_enter_polling(should_poll);
         self.set_scroll_polling(should_poll);
+        self.set_drag_and_drop_polling(should_poll);
     }
 
     /// Wrapper for `glfwSetWindowSizeCallback`.
@@ -1408,6 +1411,11 @@ impl Window {
     /// Wrapper for `glfwSetFramebufferSizeCallback`.
     pub fn set_framebuffer_size_polling(&mut self, should_poll: bool) {
         set_window_callback!(self, should_poll, glfwSetFramebufferSizeCallback, framebuffer_size_callback);
+    }
+
+    /// Wrapper for `glfwSetFramebufferSizeCallback`.
+    pub fn set_drag_and_drop_polling(&mut self, should_poll: bool) {
+        set_window_callback!(self, should_poll, glfwSetDropCallback, drop_callback);
     }
 
     /// Wrapper for `glfwGetInputMode` called with `CURSOR`.


### PR DESCRIPTION
Registers the drag and drop callback optionally when calling set_drag_and_drop_polling and adds a new event: Dropped(Vec<PathBuf>)

Because of the new event, WindowEvent can't be Copy anynmore which might break some code