### PR TITLE
Change Context refs to immutable. Fix #340

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1162,7 +1162,7 @@ impl Window {
     /// current context, it will make it the current context.
     ///
     /// Wrapper for `glfwGetProcAddress`.
-    pub fn get_proc_address(&mut self, procname: &str) -> GLProc {
+    pub fn get_proc_address(&self, procname: &str) -> GLProc {
         if self.ptr != unsafe { ffi::glfwGetCurrentContext() } {
             self.make_current();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1603,7 +1603,7 @@ pub trait Context {
     /// updates before swapping the buffers.
     ///
     /// Wrapper for `glfwSwapBuffers`.
-    fn swap_buffers(&mut self) {
+    fn swap_buffers(&self) {
         let ptr = self.window_ptr();
         unsafe { ffi::glfwSwapBuffers(ptr); }
     }
@@ -1614,7 +1614,7 @@ pub trait Context {
     }
 
     /// Wrapper for `glfwMakeContextCurrent`
-    fn make_current(&mut self) {
+    fn make_current(&self) {
         let ptr = self.window_ptr();
         unsafe { ffi::glfwMakeContextCurrent(ptr); }
     }


### PR DESCRIPTION
#### What?
This small PR changes `self` references in `Context` to use `&self` instead of `&mut self`.
#### Why?
There doesn't seem to be any reason to require a mutable reference to the `Context`. According to the `glfw` docs, both `glfwSwapBuffers` and `glfwMakeContextCurrent` can be called from any thread asynchronously.

Using `&self` in `make_current` **does** allow one thread to "steal" another thread's context, causing the thread whose context was stolen to generate GL errors, but that would still be possible if one were to use a `Mutex` or an `RwLock` on whatever implements the `Context`. Hence, `glfw-rs` does not prevent such a situation, and it's the user's job not to call GL funcs without an active context on the calling thread. If there is any reason for using `&mut` that I missed, feel free to close this, but please explain why. Otherwise, it would be nice to have more lax requirements on the `Context`, specifically for interop with `glium`, which has `&self` references on a trait that is supposed to supply buffer swapping and context switching.

__edit__: Noticed something about `get_proc_address`, so please don't merge for now.