### PR TITLE
Added the ability to terminate GLFW manually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ image = "^0.13"
 all = ["image", "vulkan"]
 default = ["glfw-sys"]
 vulkan = ["vk-sys"]
+terminate_manually = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,14 +657,27 @@ pub fn init<UserData: 'static>(mut callback: Option<ErrorCallback<UserData>>) ->
             }
             if ffi::glfwInit() == ffi::TRUE {
                 result = Ok(());
-                // TODO: When (if?) std::rt::at_exit() stabilizes, prefer to use it.
-                libc::atexit(glfw_terminate);
+                if !(cfg!(feature = "terminate_manually")) {
+                    // TODO: When (if?) std::rt::at_exit() stabilizes, prefer to use it.
+                    libc::atexit(glfw_terminate);
+                }
             } else {
                 result = Err(InitError::Internal);
             }
         })
     }
     result.map(|_| Glfw)
+}
+
+/// Manually terminate the GLFW library. This must be called on the main
+/// platform thread. It's not necessary to call this function unless you have
+/// enabled the `terminate_manually` feature. 
+///
+/// Wrapper for 'glfwTerminate'.
+pub fn terminate() {
+    unsafe {
+        ffi::glfwTerminate();
+    }
 }
 
 impl Glfw {


### PR DESCRIPTION
## Synopsis

Hi there! I recently ran into a problem using `glfw-rs` in a Rust library called from a Mac App. My solution necessitated being able to manually terminate the GLFW library. After adding the feature in my own fork, I figured I'd share it back in case you'd like to incorporate it.

## The Problem

When making a Mac App, Apple's AppKit creates its own `NSAutoreleasePool` object to manage autoreleased Objective-C objects. The underlying GLFW C library creates its own `NSAutoreleasePool` objects as well.  As it is right now, using `glfw-rs` from an AppKit app on the main thread crashes, due to the way these two sets of `NSAutoreleasePool` objects interact.

The problem is that `NSAutoreleasePool` objects must be strictly nested inside of each other per-thread. So, for example, it will crash if you create Pool A, then create Pool B, then drain Pool A, then drain Pool B - the only order that won't cause a crash is (Create A) (Create B) (Drain B) (Drain A).

Currently, when the process that `glfw-rs` was initialized on ends, it calls  calls `glfwTerminate()`, which drains GLFW's autorelease pool. Note that this will always happen _after_ Apple's AppKit autorelease pool has been drained, causing the pools to be drained in the wrong order.

I'm guessing that this hasn't come up before because the typical usage of GLFW would be outside the AppKit framework. Still, there's nothing in the GLFW C library that should prohibit it from being used inside a Mac App that uses AppKit.

## Solution

The solution I came to is to manually call `glfwTerminate()` before the AppKit thread ends, making the pools drain in the correct order.

The way that `glfw-rs` currently handles termination is very ergonomic, so I thought the best option would be to add a feature flag which would allow users to opt-in to manual termination if they need to without causing any breaking changes.

Thanks!