### PR TITLE
key_name() and name() cause segfaults, add safe functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "glfw"
 readme = "README.md"
 repository = "https://github.com/bjz/glfw-rs"
-version = "0.15.0"
+version = "0.16.0"
 
 [dependencies]
 bitflags = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,23 @@ pub enum Key {
 }
 
 /// Wrapper around 'glfwGetKeyName`
+pub fn get_key_name(key: Option<Key>, scancode: Option<Scancode>) -> Option<String> {
+    unsafe {
+        let key_ptr =
+            ffi::glfwGetKeyName(match key {
+                Some(k) => k as c_int,
+                None => ffi::KEY_UNKNOWN
+            }, scancode.unwrap_or(ffi::KEY_UNKNOWN));
+        if key_ptr.is_null() {
+            None
+        } else {
+            Some(string_from_c_str(key_ptr))
+        }
+    }
+}
+
+/// Wrapper around 'glfwGetKeyName`
+#[deprecated(since = "0.16.0", note = "'key_name' can cause a segfault, use 'get_key_name' instead")]
 pub fn key_name(key: Option<Key>, scancode: Option<Scancode>) -> String {
     unsafe {
         string_from_c_str(ffi::glfwGetKeyName(match key {
@@ -268,8 +285,15 @@ pub fn key_name(key: Option<Key>, scancode: Option<Scancode>) -> String {
 
 impl Key {
     /// Wrapper around 'glfwGetKeyName` without scancode
+    #[deprecated(since = "0.16.0", note = "Key method 'name' can cause a segfault, use 'get_name' instead")]
     pub fn name(&self) -> String {
+        #[allow(deprecated)]
         key_name(Some(*self), None)
+    }
+
+    /// Wrapper around 'glfwGetKeyName` without scancode
+    pub fn get_name(&self) -> Option<String> {
+	    get_key_name(Some(*self), None)
     }
 }
 


### PR DESCRIPTION
# Problem
`key_name(key: Option<Key>, scancode: Option<Scancode>) -> String` and its associated wrapper method `Key::name(&self) -> String` can cause a segmentation fault (crashing the program without useful information), as it does not take into account the behaviour of  `const char* glfwGetKeyName( int key, int scancode)`.

`glfwGetKeyName()` returns a null pointer many inputs, such as SHIFT or SPACE. Quoting from [the GLFW3 doc for glfwGetKeyName](http://www.glfw.org/docs/latest/group__input.html#ga237a182e5ec0b21ce64543f3b5e7e2be)...

> If a non-printable key or (if the key is GLFW_KEY_UNKNOWN) a scancode that maps to a non-printable key is specified, this function returns NULL.

View the given for a list of "printable keys".

The current code will try and dereference a null pointer inside of `string_from_c_str(c_str: *const c_char) -> String`, causing a crash via segmentation fault.

# Solution

Deprecate the aforementioned functions, and add `get_key_name(key: Option<Key>, scancode: Option<Scancode>) -> Option<String>` and `Key::get_name(&self) -> Option<String>`, which check for a null pointer. This more accurately reflects the actual behaviour of C GLFW