### PR TITLE
Fix Travis CI build and clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,16 @@
 # limitations under the License.
 
 language: rust
-env:
-  global:
-    - LD_LIBRARY_PATH: /usr/local/lib
-    - secure: d0ai0sK6NFiz+822DaAKAGcJXjC6dBFLGOjqjACcsoqDtRH85HR9IVUnwCsNVPvH05frEutD5Ebd9SzrjqPriTNnzM0iwZZBxHgiHV+SAYcL/D+qyeEAB/IYU5jZxjYgq/6fHA2VhXI56rGqBRwoXe1sLsEAaTfDmo9gVi6xhQo=  echo "yes" | sudo add-apt-repository ppa:kalakris/cmake
-before_install:
-  # install a newer cmake since at this time Travis only has version 2.8.7
-  - yes | sudo add-apt-repository ppa:kubuntu-ppa/backports
-  - sudo apt-get update -qq
-install: sudo apt-get install cmake libXxf86vm-dev libxinerama-dev libxcursor-dev
+addons:
+  apt:
+    sources:
+      - kubuntu-backports
+    packages:
+      - libxinerama-dev
+      - libxcursor-dev
+      - xorg-dev
 script:
   - cargo build --features "all"
   - cargo test --features "all"
   - cargo doc --features "all"
-after_script:
-  # the doc directory needs to be in the root for rust-ci
-  - mv target/doc doc
-  - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
+

--- a/README.md
+++ b/README.md
@@ -92,28 +92,6 @@ git = "https://github.com/bjz/glfw-rs.git"
 default-features = false
 ~~~
 
-### A note about Travis CI
-
-You may encounter the following error when attempting to build your project on Travis:
-
-~~~
-CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
-  CMake 2.8.9 or higher is required.  You are running version 2.8.7
-~~~
-
-This is because Travis CI _still_ hasn't updated their CMake version almost a year since the issue
-was reported (See travis-ci/travis-ci#2030). Because of this, you will need to [add the following
-build commands](https://github.com/travis-ci/travis-ci/issues/2030#issuecomment-49210009) to your
-`.travis.yml`:
-
-~~~yml
-before_install:
-  # install a newer cmake since at this time Travis only has version 2.8.7
-  - yes | sudo add-apt-repository ppa:kalakris/cmake
-  - sudo apt-get update -qq
-install: sudo apt-get install cmake
-~~~
-
 ## Support
 
 Contact `bjz` on irc.mozilla.org [#rust](http://mibbit.com/?server=irc.mozilla.org&channel=%23rust)


### PR DESCRIPTION
Resolves #369.

An overview of the changes made:

The error `E: Unable to locate package libXxf86vm-dev` occurs because there is a typo in the package name, the correct name of the package is `libxxf86vm-dev` (lower case x). In any case, this package is installed by default in Trusty so I removed it.

The build was running into problems with a CMake build which stated that `The RandR library and headers were not found`. After looking [here](https://github.com/openMVG/openMVG/issues/85), this was resolved by installing the `xorg-dev` and  `libglu1-mesa-dev`, but since the latter is already installed in Trusty I just added the former.

CMake is now at 3.2.2 in Trusty and installed by default so I removed this package from the list that are installed.

In summary, the dependencies added are:
- `xorg-dev`

Dependencies removed:
- `cmake`
- `libxxf86vm-dev`

I changed the previous way of installing dependencies to use the [TravisCI apt addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-with-the-APT-Addon). It is in beta, but is more human-readable.

I also removed the environment variables to `/usr/local/lib` and the secure key, and also removed the commands post script related to Rust CI. The latter is a service that has been replaced by docs.rs.