### PR TITLE
Published 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ license = "Apache-2.0"
 name = "glfw"
 readme = "README.md"
 repository = "https://github.com/bjz/glfw-rs"
-version = "0.18.0"
+version = "0.19.0"
 
 [dependencies]
-bitflags = "0.9.1"
+bitflags = "1.0.0"
 enum_primitive = "0.1"
 libc = "0.2"
 log = "0.3"
@@ -22,7 +22,7 @@ version = "^3.2"
 
 [dependencies.image]
 optional = true
-version = "^0.16"
+version = "^0.17"
 
 [dependencies.vk-sys]
 optional = true
@@ -30,7 +30,7 @@ version = "^0.2"
 
 [dev-dependencies]
 vk-sys = "^0.2"
-image = "^0.16"
+image = "^0.17"
 
 [features]
 all = ["image", "vulkan"]

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -36,10 +36,10 @@ fn main() {
 }
 
 #[cfg(target_os = "macos")]
-static NATIVE_MOD: glfw::modifiers::Modifiers = glfw::modifiers::Super;
+static NATIVE_MOD: glfw::Modifiers = glfw::Modifiers::Super;
 
 #[cfg(not(target_os = "macos"))]
-static NATIVE_MOD: glfw::modifiers::Modifiers = glfw::modifiers::Control;
+static NATIVE_MOD: glfw::Modifiers = glfw::Modifiers::Control;
 
 fn handle_window_event(window: &mut glfw::Window, event: glfw::WindowEvent) {
     match event {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -152,11 +152,11 @@ window_callback!(fn window_refresh_callback()                                   
 window_callback!(fn window_focus_callback(focused: c_int)                                   => Focus(focused == ffi::TRUE));
 window_callback!(fn window_iconify_callback(iconified: c_int)                               => Iconify(iconified == ffi::TRUE));
 window_callback!(fn framebuffer_size_callback(width: c_int, height: c_int)                  => FramebufferSize(width as i32, height as i32));
-window_callback!(fn mouse_button_callback(button: c_int, action: c_int, mods: c_int)        => MouseButton(mem::transmute(button), mem::transmute(action), modifiers::Modifiers::from_bits(mods).unwrap()));
+window_callback!(fn mouse_button_callback(button: c_int, action: c_int, mods: c_int)        => MouseButton(mem::transmute(button), mem::transmute(action), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn cursor_pos_callback(xpos: c_double, ypos: c_double)                     => CursorPos(xpos as f64, ypos as f64));
 window_callback!(fn cursor_enter_callback(entered: c_int)                                   => CursorEnter(entered == ffi::TRUE));
 window_callback!(fn scroll_callback(xpos: c_double, ypos: c_double)                         => Scroll(xpos as f64, ypos as f64));
-window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => Key(mem::transmute(key), scancode, mem::transmute(action), modifiers::Modifiers::from_bits(mods).unwrap()));
+window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mods: c_int)   => Key(mem::transmute(key), scancode, mem::transmute(action), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn char_callback(character: c_uint)                                        => Char(::std::char::from_u32(character).unwrap()));
-window_callback!(fn char_mods_callback(character: c_uint, mods: c_int)                      => CharModifiers(::std::char::from_u32(character).unwrap(), modifiers::Modifiers::from_bits(mods).unwrap()));
+window_callback!(fn char_mods_callback(character: c_uint, mods: c_int)                      => CharModifiers(::std::char::from_u32(character).unwrap(), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn drop_callback(num_paths: c_int, paths: *mut *const c_char)              => FileDrop(slice::from_raw_parts(paths, num_paths as usize).iter().map(|path| PathBuf::from(str::from_utf8(CStr::from_ptr(*path).to_bytes()).unwrap().to_string())).collect()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1476,15 +1476,13 @@ impl<'a> WindowMode<'a> {
 }
 
 /// Key modifiers (e.g., Shift, Control, Alt, Super)
-pub mod modifiers {
-    bitflags! {
-        #[doc = "Key modifiers"]
-        pub struct Modifiers: ::libc::c_int {
-            const Shift       = ::ffi::MOD_SHIFT;
-            const Control     = ::ffi::MOD_CONTROL;
-            const Alt         = ::ffi::MOD_ALT;
-            const Super       = ::ffi::MOD_SUPER;
-        }
+bitflags! {
+    #[doc = "Key modifiers"]
+    pub struct Modifiers: ::libc::c_int {
+        const Shift       = ::ffi::MOD_SHIFT;
+        const Control     = ::ffi::MOD_CONTROL;
+        const Alt         = ::ffi::MOD_ALT;
+        const Super       = ::ffi::MOD_SUPER;
     }
 }
 
@@ -1501,13 +1499,13 @@ pub enum WindowEvent {
     Focus(bool),
     Iconify(bool),
     FramebufferSize(i32, i32),
-    MouseButton(MouseButton, Action, modifiers::Modifiers),
+    MouseButton(MouseButton, Action, Modifiers),
     CursorPos(f64, f64),
     CursorEnter(bool),
     Scroll(f64, f64),
-    Key(Key, Scancode, Action, modifiers::Modifiers),
+    Key(Key, Scancode, Action, Modifiers),
     Char(char),
-    CharModifiers(char, modifiers::Modifiers),
+    CharModifiers(char, Modifiers),
     FileDrop(Vec<PathBuf>),
 }
 


### PR DESCRIPTION
- Updated dependencies
- Moved `Modifiers` one level up because variants in bitflags 1.0.0 are
in namespace `Modifiers`