### PR TITLE
Link shell32 on windows

### DIFF
--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -32,6 +32,7 @@ extern {}
 #[link(name = "opengl32")]
 #[link(name = "gdi32")]
 #[link(name = "user32")]
+#[link(name = "shell32")]
 extern {}
 
 #[cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly"))]


### PR DESCRIPTION
shell32 is no longer implicitly linked by rustc.

https://github.com/rust-lang/rust/issues/56839