### PR TITLE
Handle null pointers returned by glfw correctly

### DIFF
--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -50,8 +50,8 @@ fn handle_window_event(window: &mut glfw::Window, event: glfw::WindowEvent) {
                 }
                 if (key == Key::V) && mods.contains(NATIVE_MOD) {
                     match window.get_clipboard_string() {
-                        ref s if !s.is_empty() => println!("Clipboard contains \"{:?}\"", *s),
-                        _                      => println!("Clipboard does not contain a string"),
+                        Some(ref s) if !s.is_empty() => println!("Clipboard contains \"{:?}\"", *s),
+                        _                            => println!("Clipboard does not contain a string"),
                     }
                 }
                 if (key == Key::C) && mods.contains(NATIVE_MOD) {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -59,7 +59,7 @@ fn main() {
 
                             window.set_monitor(glfw::WindowMode::FullScreen(&monitor), 0, 0, mode.width, mode.height, Some(mode.refresh_rate));
 
-                            println!("{}x{} fullscreen enabled at {}Hz on monitor {}", mode.width, mode.height, mode.refresh_rate, monitor.get_name());
+                            println!("{}x{} fullscreen enabled at {}Hz on monitor {}", mode.width, mode.height, mode.refresh_rate, monitor.get_name().unwrap());
                         });
                     }
 


### PR DESCRIPTION
This PR changes the return type of some wrapper functions from `String` to `Option<String>` as the underlying glfw function may return a null pointer. This is now handled correctly by returning a `None` using the new `string_from_nullable_c_str` helper function.