### PR TITLE
Update for glfw 3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ semver = "0.2"
 
 [dependencies.glfw-sys]
 optional = true
-version = "^3.2"
+version = "^3.3"
 
 [dependencies.image]
 optional = true

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -43,6 +43,8 @@ fn main() {
     window.set_cursor_pos_polling(true);
     window.set_cursor_enter_polling(true);
     window.set_scroll_polling(true);
+    window.set_maximize_polling(true);
+    window.set_content_scale_polling(true);
 
     // Alternatively, all event types may be set to poll at once. Note that
     // in this example, this call is redundant as all events have been set
@@ -91,5 +93,7 @@ fn handle_window_event(window: &mut glfw::Window, (time, event): (f64, glfw::Win
             }
         }
         glfw::WindowEvent::FileDrop(paths)                => println!("Time: {:?}, Files dropped: {:?}", time, paths),
+        glfw::WindowEvent::Maximize(maximized) => println!("Time: {:?}, Window maximized: {:?}.", time, maximized),
+        glfw::WindowEvent::ContentScale(xscale, yscale) => println!("Time: {:?}, Content scale x: {:?}, Content scale y: {:?}", time, xscale, yscale),
     }
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -160,3 +160,5 @@ window_callback!(fn key_callback(key: c_int, scancode: c_int, action: c_int, mod
 window_callback!(fn char_callback(character: c_uint)                                        => Char(::std::char::from_u32(character).unwrap()));
 window_callback!(fn char_mods_callback(character: c_uint, mods: c_int)                      => CharModifiers(::std::char::from_u32(character).unwrap(), Modifiers::from_bits(mods).unwrap()));
 window_callback!(fn drop_callback(num_paths: c_int, paths: *mut *const c_char)              => FileDrop(slice::from_raw_parts(paths, num_paths as usize).iter().map(|path| PathBuf::from(str::from_utf8(CStr::from_ptr(*path).to_bytes()).unwrap().to_string())).collect()));
+window_callback!(fn window_maximize_callback(maximized: c_int)                              => Maximize(maximized == ffi::TRUE));
+window_callback!(fn window_content_scale_callback(xscale: c_float, yscale: c_float)         => ContentScale(xscale as f32, yscale as f32));

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -168,6 +168,8 @@ pub const MOD_SHIFT                    : c_int = 0x0001;
 pub const MOD_CONTROL                  : c_int = 0x0002;
 pub const MOD_ALT                      : c_int = 0x0004;
 pub const MOD_SUPER                    : c_int = 0x0008;
+pub const MOD_CAPS_LOCK                : c_int = 0x0010;
+pub const MOD_NUM_LOCK                 : c_int = 0x0020;
 
 pub const JOYSTICK_1                   : c_int = 0;
 pub const JOYSTICK_2                   : c_int = 1;
@@ -200,6 +202,47 @@ pub const MOUSE_BUTTON_RIGHT           : c_int = MOUSE_BUTTON_2;
 pub const MOUSE_BUTTON_MIDDLE          : c_int = MOUSE_BUTTON_3;
 pub const MOUSE_BUTTON_LAST            : c_int = MOUSE_BUTTON_8;
 
+// TODO
+pub const HAT_CENTERED                 : c_int = 0b0000;
+pub const HAT_UP                       : c_int = 0b0001;
+pub const HAT_RIGHT                    : c_int = 0b0010;
+pub const HAT_DOWN                     : c_int = 0b0100;
+pub const HAT_LEFT                     : c_int = 0b1000;
+pub const HAT_RIGHT_UP                 : c_int = HAT_RIGHT | HAT_UP;
+pub const HAT_RIGHT_DOWN               : c_int = HAT_RIGHT | HAT_DOWN;
+pub const HAT_LEFT_UP                  : c_int = HAT_LEFT | HAT_UP;
+pub const HAT_LEFT_DOWN                : c_int = HAT_LEFT | HAT_DOWN;
+
+pub const GAMEPAD_BUTTON_A             : c_int = 0;
+pub const GAMEPAD_BUTTON_B             : c_int = 1;
+pub const GAMEPAD_BUTTON_X             : c_int = 2;
+pub const GAMEPAD_BUTTON_Y             : c_int = 3;
+pub const GAMEPAD_BUTTON_LEFT_BUMPER   : c_int = 4;
+pub const GAMEPAD_BUTTON_RIGHT_BUMPER  : c_int = 5;
+pub const GAMEPAD_BUTTON_BACK          : c_int = 6;
+pub const GAMEPAD_BUTTON_START         : c_int = 7;
+pub const GAMEPAD_BUTTON_GUIDE         : c_int = 8;
+pub const GAMEPAD_BUTTON_LEFT_THUMB    : c_int = 9;
+pub const GAMEPAD_BUTTON_RIGHT_THUMB   : c_int = 10;
+pub const GAMEPAD_BUTTON_DPAD_UP       : c_int = 11;
+pub const GAMEPAD_BUTTON_DPAD_RIGHT    : c_int = 12;
+pub const GAMEPAD_BUTTON_DPAD_DOWN     : c_int = 13;
+pub const GAMEPAD_BUTTON_DPAD_LEFT     : c_int = 14;
+pub const GAMEPAD_BUTTON_DPAD_LAST     : c_int = GAMEPAD_BUTTON_DPAD_LEFT;
+pub const GAMEPAD_BUTTON_DPAD_CROSS    : c_int = GAMEPAD_BUTTON_A;
+pub const GAMEPAD_BUTTON_DPAD_CIRCLE   : c_int = GAMEPAD_BUTTON_B;
+pub const GAMEPAD_BUTTON_DPAD_SQUARE   : c_int = GAMEPAD_BUTTON_X;
+pub const GAMEPAD_BUTTON_DPAD_TRIANGLE : c_int = GAMEPAD_BUTTON_Y;
+
+pub const GAMEPAD_AXIS_LEFT_X          : c_int = 0;
+pub const GAMEPAD_AXIS_LEFT_Y          : c_int = 1;
+pub const GAMEPAD_AXIS_RIGHT_X         : c_int = 2;
+pub const GAMEPAD_AXIS_RIGHT_Y         : c_int = 3;
+pub const GAMEPAD_AXIS_LEFT_TRIGGER    : c_int = 4;
+pub const GAMEPAD_AXIS_RIGHT_TRIGGER   : c_int = 5;
+pub const GAMEPAD_AXIS_LAST            : c_int = GAMEPAD_AXIS_RIGHT_TRIGGER;
+
+pub const NO_ERROR                     : c_int = 0;
 pub const NOT_INITIALIZED              : c_int = 0x00010001;
 pub const NO_CURRENT_CONTEXT           : c_int = 0x00010002;
 pub const INVALID_ENUM                 : c_int = 0x00010003;
@@ -219,6 +262,10 @@ pub const DECORATED                    : c_int = 0x00020005;
 pub const AUTO_ICONIFY                 : c_int = 0x00020006;
 pub const FLOATING                     : c_int = 0x00020007;
 pub const MAXIMIZED                    : c_int = 0x00020008;
+pub const CENTER_CURSOR                : c_int = 0x00020009;
+pub const TRANSPARENT_FRAMEBUFFER      : c_int = 0x0002000A; // TODO: attribute
+pub const HOVERED                      : c_int = 0x0002000B; // TODO: attribute
+pub const FOCUS_ON_SHOW                : c_int = 0x0002000C; // TODO: attribute
 
 pub const RED_BITS                     : c_int = 0x00021001;
 pub const GREEN_BITS                   : c_int = 0x00021002;
@@ -248,6 +295,14 @@ pub const OPENGL_PROFILE               : c_int = 0x00022008;
 pub const CONTEXT_RELEASE_BEHAVIOR     : c_int = 0x00022009;
 pub const CONTEXT_NO_ERROR             : c_int = 0x0002200A;
 pub const CONTEXT_CREATION_API         : c_int = 0x0002200B;
+pub const SCALE_TO_MONITOR             : c_int = 0x0002200C;
+
+pub const COCOA_RETINA_FRAMEBUFFER     : c_int = 0x00023001;
+pub const COCOA_FRAME_NAME             : c_int = 0x00023002;
+pub const COCOA_GRAPHICS_SWITCHING     : c_int = 0x00023003;
+
+pub const X11_CLASS_NAME               : c_int = 0x00024001;
+pub const X11_INSTANCE_NAME            : c_int = 0x00024002;
 
 pub const NO_API                       : c_int = 0x00000000;
 pub const OPENGL_API                   : c_int = 0x00030001;
@@ -264,6 +319,8 @@ pub const OPENGL_COMPAT_PROFILE        : c_int = 0x00032002;
 pub const CURSOR                       : c_int = 0x00033001;
 pub const STICKY_KEYS                  : c_int = 0x00033002;
 pub const STICKY_MOUSE_BUTTONS         : c_int = 0x00033003;
+pub const LOCK_KEY_MODS                : c_int = 0x00033004;
+pub const RAW_MOUSE_MOTION             : c_int = 0x00033005;
 
 pub const CURSOR_NORMAL                : c_int = 0x00034001;
 pub const CURSOR_HIDDEN                : c_int = 0x00034002;
@@ -275,6 +332,7 @@ pub const RELEASE_BEHAVIOR_NONE        : c_int = 0x00035002;
 
 pub const NATIVE_CONTEXT_API           : c_int = 0x00036001;
 pub const EGL_CONTEXT_API              : c_int = 0x00036002;
+pub const OSMESA_CONTEXT_API           : c_int = 0x00036003;
 
 pub const ARROW_CURSOR                 : c_int = 0x00036001;
 pub const IBEAM_CURSOR                 : c_int = 0x00036002;
@@ -288,29 +346,36 @@ pub const DISCONNECTED                 : c_int = 0x00040002;
 
 pub const DONT_CARE                    : c_int = -1; //negative one is the correct value
 
-pub type GLFWglproc             = *const c_void;
+// TODO
+pub const JOYSTICK_HAT_BUTTONS         : c_int = 0x00050001;
+pub const COCOA_CHDIR_RESOURCES        : c_int = 0x00051001;
+pub const COCOA_MENUBAR                : c_int = 0x00051002;
+
+pub type GLFWglproc                = *const c_void;
 
 #[cfg(feature = "vulkan")]
-pub type GLFWvkproc             = *const c_void;
+pub type GLFWvkproc                = *const c_void;
 
-pub type GLFWerrorfun           = extern "C" fn(c_int, *const c_char);
-pub type GLFWwindowposfun       = extern "C" fn(*mut GLFWwindow, c_int, c_int);
-pub type GLFWwindowsizefun      = extern "C" fn(*mut GLFWwindow, c_int, c_int);
-pub type GLFWwindowclosefun     = extern "C" fn(*mut GLFWwindow);
-pub type GLFWwindowrefreshfun   = extern "C" fn(*mut GLFWwindow);
-pub type GLFWwindowfocusfun     = extern "C" fn(*mut GLFWwindow, c_int);
-pub type GLFWwindowiconifyfun   = extern "C" fn(*mut GLFWwindow, c_int);
-pub type GLFWframebuffersizefun = extern "C" fn(*mut GLFWwindow, c_int, c_int);
-pub type GLFWmousebuttonfun     = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int);
-pub type GLFWcursorposfun       = extern "C" fn(*mut GLFWwindow, c_double, c_double);
-pub type GLFWcursorenterfun     = extern "C" fn(*mut GLFWwindow, c_int);
-pub type GLFWscrollfun          = extern "C" fn(*mut GLFWwindow, c_double, c_double);
-pub type GLFWkeyfun             = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int, c_int);
-pub type GLFWcharfun            = extern "C" fn(*mut GLFWwindow, c_uint);
-pub type GLFWcharmodsfun        = extern "C" fn(*mut GLFWwindow, c_uint, c_int); // TODO: Not yet exposed
-pub type GLFWdropfun            = extern "C" fn(*mut GLFWwindow, c_int, *mut *const c_char); // TODO: Not yet exposed
-pub type GLFWmonitorfun         = extern "C" fn(*mut GLFWmonitor, c_int);
-pub type GLFWjoystickfun        = extern "C" fn(c_int, c_int);
+pub type GLFWerrorfun              = extern "C" fn(c_int, *const c_char);
+pub type GLFWwindowposfun          = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWwindowsizefun         = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWwindowclosefun        = extern "C" fn(*mut GLFWwindow);
+pub type GLFWwindowrefreshfun      = extern "C" fn(*mut GLFWwindow);
+pub type GLFWwindowfocusfun        = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWwindowiconifyfun      = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWframebuffersizefun    = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWmousebuttonfun        = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int);
+pub type GLFWcursorposfun          = extern "C" fn(*mut GLFWwindow, c_double, c_double);
+pub type GLFWcursorenterfun        = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWscrollfun             = extern "C" fn(*mut GLFWwindow, c_double, c_double);
+pub type GLFWkeyfun                = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int, c_int);
+pub type GLFWcharfun               = extern "C" fn(*mut GLFWwindow, c_uint);
+pub type GLFWcharmodsfun           = extern "C" fn(*mut GLFWwindow, c_uint, c_int); // TODO: Not yet exposed
+pub type GLFWdropfun               = extern "C" fn(*mut GLFWwindow, c_int, *mut *const c_char); // TODO: Not yet exposed
+pub type GLFWmonitorfun            = extern "C" fn(*mut GLFWmonitor, c_int);
+pub type GLFWjoystickfun           = extern "C" fn(c_int, c_int);
+pub type GLFWwindowmaximizefun     = extern "C" fn(*mut GLFWwindow, c_int); // TODO: Not yet exposed
+pub type GLFWwindowcontentscalefun = extern "C" fn(*mut GLFWwindow, c_float, c_float); // TODO: Not yet exposed
 
 #[allow(missing_copy_implementations)]
 pub enum GLFWmonitor {}
@@ -348,6 +413,13 @@ pub struct GLFWimage {
     pub width: c_int,
     pub height: c_int,
     pub pixels: *const c_uchar,
+}
+
+#[allow(missing_copy_implementations)]
+#[repr(C)]
+pub struct GLFWgamepadstate {
+    pub buttons: [c_uchar; 15],
+    pub axes:    [c_float; 6],
 }
 
 // C function bindings
@@ -455,6 +527,33 @@ extern "C" {
     pub fn glfwGetTimerValue() -> c_ulonglong; //uint64_t
     pub fn glfwGetTimerFrequency() -> c_ulonglong; //uint64_t
     pub fn glfwSetJoystickCallback(cbjoy: Option<GLFWjoystickfun>) -> Option<GLFWjoystickfun>;
+
+    // Added in 3.3
+
+    pub fn glfwInitHint(hint: c_int, value: c_int); // TODO
+    pub fn glfwGetError(description: *mut *const c_char) -> c_int; // TODO
+    pub fn glfwGetMonitorWorkarea(monitor: *mut GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int, width: *mut c_int, height: *mut c_int); // TODO
+    pub fn glfwGetMonitorContentScale(monitor: *mut GLFWmonitor, xscale: *mut c_float, yscale: *mut c_float); // TODO
+    pub fn glfwGetMonitorUserPointer(monitor: *mut GLFWmonitor) -> *mut c_void; // TODO
+    pub fn glfwSetMonitorUserPointer(monitor: *mut GLFWmonitor, pointer: *mut c_void); // TODO
+    pub fn glfwWindowHintString(hint: c_int, value: *const c_char);
+    pub fn glfwGetWindowContentScale(window: *mut GLFWwindow, xscale: *mut c_float, yscale: *mut c_float); // TODO
+    pub fn glfwGetWindowOpacity(window: *mut GLFWwindow) -> c_float; // TODO
+    pub fn glfwSetWindowOpacity(window: *mut GLFWwindow, opacity: c_float); // TODO
+    pub fn glfwRequestWindowAttention(window: *mut GLFWwindow); // TODO
+    pub fn glfwSetWindowAttrib(window: *mut GLFWwindow, attrib: c_int, value: c_int); // TODO
+    pub fn glfwSetWindowMaximizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowmaximizefun>) -> Option<GLFWwindowmaximizefun>; // TODO
+    pub fn glfwGetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>; // TODO
+    pub fn glfwRawMouseMotionSupported() -> c_int; // TODO
+    pub fn glfwGetKeyScancode(key: c_int) -> c_int; // TODO
+    pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar; // TODO
+    pub fn glfwGetJoystickGUID(jid: c_int) -> *const c_char; // TODO
+    pub fn glfwGetJoystickUserPointer(jid: c_int) -> *mut c_void; // TODO
+    pub fn glfwSetJoystickUserPointer(jid: c_int, pointer: *mut c_void); // TODO
+    pub fn glfwJoystickIsGamepad(jid: c_int) -> c_int; // TODO
+    pub fn glfwUpdateGamepadMappings(string: *const c_char) -> c_int; // TODO
+    pub fn glfwGetGamepadName(jid: c_int) -> *const c_char; // TODO
+    pub fn glfwGetGamepadState(jid: c_int, state: *mut GLFWgamepadstate) -> c_int; // TODO
 
     // Vulkan support
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -263,9 +263,9 @@ pub const AUTO_ICONIFY                 : c_int = 0x00020006;
 pub const FLOATING                     : c_int = 0x00020007;
 pub const MAXIMIZED                    : c_int = 0x00020008;
 pub const CENTER_CURSOR                : c_int = 0x00020009;
-pub const TRANSPARENT_FRAMEBUFFER      : c_int = 0x0002000A; // TODO: attribute
-pub const HOVERED                      : c_int = 0x0002000B; // TODO: attribute
-pub const FOCUS_ON_SHOW                : c_int = 0x0002000C; // TODO: attribute
+pub const TRANSPARENT_FRAMEBUFFER      : c_int = 0x0002000A;
+pub const HOVERED                      : c_int = 0x0002000B;
+pub const FOCUS_ON_SHOW                : c_int = 0x0002000C;
 
 pub const RED_BITS                     : c_int = 0x00021001;
 pub const GREEN_BITS                   : c_int = 0x00021002;
@@ -533,18 +533,18 @@ extern "C" {
     pub fn glfwInitHint(hint: c_int, value: c_int); // TODO
     pub fn glfwGetError(description: *mut *const c_char) -> c_int; // TODO
     pub fn glfwGetMonitorWorkarea(monitor: *mut GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int, width: *mut c_int, height: *mut c_int); // TODO
-    pub fn glfwGetMonitorContentScale(monitor: *mut GLFWmonitor, xscale: *mut c_float, yscale: *mut c_float); // TODO
+    pub fn glfwGetMonitorContentScale(monitor: *mut GLFWmonitor, xscale: *mut c_float, yscale: *mut c_float);
     pub fn glfwGetMonitorUserPointer(monitor: *mut GLFWmonitor) -> *mut c_void; // TODO
     pub fn glfwSetMonitorUserPointer(monitor: *mut GLFWmonitor, pointer: *mut c_void); // TODO
     pub fn glfwWindowHintString(hint: c_int, value: *const c_char);
-    pub fn glfwGetWindowContentScale(window: *mut GLFWwindow, xscale: *mut c_float, yscale: *mut c_float); // TODO
-    pub fn glfwGetWindowOpacity(window: *mut GLFWwindow) -> c_float; // TODO
-    pub fn glfwSetWindowOpacity(window: *mut GLFWwindow, opacity: c_float); // TODO
-    pub fn glfwRequestWindowAttention(window: *mut GLFWwindow); // TODO
-    pub fn glfwSetWindowAttrib(window: *mut GLFWwindow, attrib: c_int, value: c_int); // TODO
+    pub fn glfwGetWindowContentScale(window: *mut GLFWwindow, xscale: *mut c_float, yscale: *mut c_float);
+    pub fn glfwGetWindowOpacity(window: *mut GLFWwindow) -> c_float;
+    pub fn glfwSetWindowOpacity(window: *mut GLFWwindow, opacity: c_float);
+    pub fn glfwRequestWindowAttention(window: *mut GLFWwindow);
+    pub fn glfwSetWindowAttrib(window: *mut GLFWwindow, attrib: c_int, value: c_int);
     pub fn glfwSetWindowMaximizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowmaximizefun>) -> Option<GLFWwindowmaximizefun>; // TODO
     pub fn glfwGetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>; // TODO
-    pub fn glfwRawMouseMotionSupported() -> c_int; // TODO
+    pub fn glfwRawMouseMotionSupported() -> c_int;
     pub fn glfwGetKeyScancode(key: c_int) -> c_int; // TODO
     pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar; // TODO
     pub fn glfwGetJoystickGUID(jid: c_int) -> *const c_char; // TODO

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -373,8 +373,8 @@ pub type GLFWcharmodsfun           = extern "C" fn(*mut GLFWwindow, c_uint, c_in
 pub type GLFWdropfun               = extern "C" fn(*mut GLFWwindow, c_int, *mut *const c_char); // TODO: Not yet exposed
 pub type GLFWmonitorfun            = extern "C" fn(*mut GLFWmonitor, c_int);
 pub type GLFWjoystickfun           = extern "C" fn(c_int, c_int);
-pub type GLFWwindowmaximizefun     = extern "C" fn(*mut GLFWwindow, c_int); // TODO: Not yet exposed
-pub type GLFWwindowcontentscalefun = extern "C" fn(*mut GLFWwindow, c_float, c_float); // TODO: Not yet exposed
+pub type GLFWwindowmaximizefun     = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWwindowcontentscalefun = extern "C" fn(*mut GLFWwindow, c_float, c_float);
 
 #[allow(missing_copy_implementations)]
 pub enum GLFWmonitor {}
@@ -541,8 +541,8 @@ extern "C" {
     pub fn glfwSetWindowOpacity(window: *mut GLFWwindow, opacity: c_float);
     pub fn glfwRequestWindowAttention(window: *mut GLFWwindow);
     pub fn glfwSetWindowAttrib(window: *mut GLFWwindow, attrib: c_int, value: c_int);
-    pub fn glfwSetWindowMaximizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowmaximizefun>) -> Option<GLFWwindowmaximizefun>; // TODO
-    pub fn glfwGetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>; // TODO
+    pub fn glfwSetWindowMaximizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowmaximizefun>) -> Option<GLFWwindowmaximizefun>;
+    pub fn glfwSetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>;
     pub fn glfwRawMouseMotionSupported() -> c_int;
     pub fn glfwGetKeyScancode(key: c_int) -> c_int;
     pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar; // TODO

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -202,12 +202,11 @@ pub const MOUSE_BUTTON_RIGHT           : c_int = MOUSE_BUTTON_2;
 pub const MOUSE_BUTTON_MIDDLE          : c_int = MOUSE_BUTTON_3;
 pub const MOUSE_BUTTON_LAST            : c_int = MOUSE_BUTTON_8;
 
-// TODO
-pub const HAT_CENTERED                 : c_int = 0b0000;
-pub const HAT_UP                       : c_int = 0b0001;
-pub const HAT_RIGHT                    : c_int = 0b0010;
-pub const HAT_DOWN                     : c_int = 0b0100;
-pub const HAT_LEFT                     : c_int = 0b1000;
+pub const HAT_CENTERED                 : c_int = 0x0000;
+pub const HAT_UP                       : c_int = 0x0001;
+pub const HAT_RIGHT                    : c_int = 0x0002;
+pub const HAT_DOWN                     : c_int = 0x0004;
+pub const HAT_LEFT                     : c_int = 0x0008;
 pub const HAT_RIGHT_UP                 : c_int = HAT_RIGHT | HAT_UP;
 pub const HAT_RIGHT_DOWN               : c_int = HAT_RIGHT | HAT_DOWN;
 pub const HAT_LEFT_UP                  : c_int = HAT_LEFT | HAT_UP;
@@ -228,11 +227,11 @@ pub const GAMEPAD_BUTTON_DPAD_UP       : c_int = 11;
 pub const GAMEPAD_BUTTON_DPAD_RIGHT    : c_int = 12;
 pub const GAMEPAD_BUTTON_DPAD_DOWN     : c_int = 13;
 pub const GAMEPAD_BUTTON_DPAD_LEFT     : c_int = 14;
-pub const GAMEPAD_BUTTON_DPAD_LAST     : c_int = GAMEPAD_BUTTON_DPAD_LEFT;
-pub const GAMEPAD_BUTTON_DPAD_CROSS    : c_int = GAMEPAD_BUTTON_A;
-pub const GAMEPAD_BUTTON_DPAD_CIRCLE   : c_int = GAMEPAD_BUTTON_B;
-pub const GAMEPAD_BUTTON_DPAD_SQUARE   : c_int = GAMEPAD_BUTTON_X;
-pub const GAMEPAD_BUTTON_DPAD_TRIANGLE : c_int = GAMEPAD_BUTTON_Y;
+pub const GAMEPAD_BUTTON_LAST          : c_int = GAMEPAD_BUTTON_DPAD_LEFT;
+pub const GAMEPAD_BUTTON_CROSS         : c_int = GAMEPAD_BUTTON_A;
+pub const GAMEPAD_BUTTON_CIRCLE        : c_int = GAMEPAD_BUTTON_B;
+pub const GAMEPAD_BUTTON_SQUARE        : c_int = GAMEPAD_BUTTON_X;
+pub const GAMEPAD_BUTTON_TRIANGLE      : c_int = GAMEPAD_BUTTON_Y;
 
 pub const GAMEPAD_AXIS_LEFT_X          : c_int = 0;
 pub const GAMEPAD_AXIS_LEFT_Y          : c_int = 1;
@@ -417,8 +416,8 @@ pub struct GLFWimage {
 #[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct GLFWgamepadstate {
-    pub buttons: [c_uchar; 15],
-    pub axes:    [c_float; 6],
+    pub buttons: [c_uchar; (GAMEPAD_BUTTON_LAST + 1) as usize],
+    pub axes:    [c_float; (GAMEPAD_AXIS_LAST + 1) as usize],
 }
 
 // C function bindings
@@ -545,14 +544,14 @@ extern "C" {
     pub fn glfwSetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>;
     pub fn glfwRawMouseMotionSupported() -> c_int;
     pub fn glfwGetKeyScancode(key: c_int) -> c_int;
-    pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar; // TODO
-    pub fn glfwGetJoystickGUID(jid: c_int) -> *const c_char; // TODO
+    pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar;
+    pub fn glfwGetJoystickGUID(jid: c_int) -> *const c_char;
     pub fn glfwGetJoystickUserPointer(jid: c_int) -> *mut c_void; // TODO
     pub fn glfwSetJoystickUserPointer(jid: c_int, pointer: *mut c_void); // TODO
-    pub fn glfwJoystickIsGamepad(jid: c_int) -> c_int; // TODO
-    pub fn glfwUpdateGamepadMappings(string: *const c_char) -> c_int; // TODO
-    pub fn glfwGetGamepadName(jid: c_int) -> *const c_char; // TODO
-    pub fn glfwGetGamepadState(jid: c_int, state: *mut GLFWgamepadstate) -> c_int; // TODO
+    pub fn glfwJoystickIsGamepad(jid: c_int) -> c_int;
+    pub fn glfwUpdateGamepadMappings(string: *const c_char) -> c_int;
+    pub fn glfwGetGamepadName(jid: c_int) -> *const c_char;
+    pub fn glfwGetGamepadState(jid: c_int, state: *mut GLFWgamepadstate) -> c_int;
 
     // Vulkan support
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -346,7 +346,6 @@ pub const DISCONNECTED                 : c_int = 0x00040002;
 
 pub const DONT_CARE                    : c_int = -1; //negative one is the correct value
 
-// TODO
 pub const JOYSTICK_HAT_BUTTONS         : c_int = 0x00050001;
 pub const COCOA_CHDIR_RESOURCES        : c_int = 0x00051001;
 pub const COCOA_MENUBAR                : c_int = 0x00051002;
@@ -530,9 +529,9 @@ extern "C" {
 
     // Added in 3.3
 
-    pub fn glfwInitHint(hint: c_int, value: c_int); // TODO
+    pub fn glfwInitHint(hint: c_int, value: c_int);
     pub fn glfwGetError(description: *mut *const c_char) -> c_int; // TODO
-    pub fn glfwGetMonitorWorkarea(monitor: *mut GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int, width: *mut c_int, height: *mut c_int); // TODO
+    pub fn glfwGetMonitorWorkarea(monitor: *mut GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int, width: *mut c_int, height: *mut c_int);
     pub fn glfwGetMonitorContentScale(monitor: *mut GLFWmonitor, xscale: *mut c_float, yscale: *mut c_float);
     pub fn glfwGetMonitorUserPointer(monitor: *mut GLFWmonitor) -> *mut c_void; // TODO
     pub fn glfwSetMonitorUserPointer(monitor: *mut GLFWmonitor, pointer: *mut c_void); // TODO
@@ -545,7 +544,7 @@ extern "C" {
     pub fn glfwSetWindowMaximizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowmaximizefun>) -> Option<GLFWwindowmaximizefun>; // TODO
     pub fn glfwGetWindowContentScaleCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowcontentscalefun>) -> Option<GLFWwindowcontentscalefun>; // TODO
     pub fn glfwRawMouseMotionSupported() -> c_int;
-    pub fn glfwGetKeyScancode(key: c_int) -> c_int; // TODO
+    pub fn glfwGetKeyScancode(key: c_int) -> c_int;
     pub fn glfwGetJoystickHats(jid: c_int, count: *mut c_int) -> *const c_uchar; // TODO
     pub fn glfwGetJoystickGUID(jid: c_int) -> *const c_char; // TODO
     pub fn glfwGetJoystickUserPointer(jid: c_int) -> *mut c_void; // TODO

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1696,6 +1696,8 @@ pub enum WindowEvent {
     Char(char),
     CharModifiers(char, Modifiers),
     FileDrop(Vec<PathBuf>),
+    Maximize(bool),
+    ContentScale(f32, f32),
 }
 
 /// Returns an iterator that yields until no more messages are contained in the
@@ -2145,6 +2147,8 @@ impl Window {
         self.set_cursor_enter_polling(should_poll);
         self.set_scroll_polling(should_poll);
         self.set_drag_and_drop_polling(should_poll);
+        self.set_maximize_polling(should_poll);
+        self.set_content_scale_polling(should_poll);
     }
 
     /// Wrapper for `glfwSetWindowSizeCallback`.
@@ -2180,6 +2184,16 @@ impl Window {
     /// Wrapper for `glfwSetFramebufferSizeCallback`.
     pub fn set_drag_and_drop_polling(&mut self, should_poll: bool) {
         set_window_callback!(self, should_poll, glfwSetDropCallback, drop_callback);
+    }
+
+    /// Wrapper for `glfwSetWindowMaximizeCallback`.
+    pub fn set_maximize_polling(&mut self, should_poll: bool) {
+        set_window_callback!(self, should_poll, glfwSetWindowMaximizeCallback, window_maximize_callback);
+    }
+
+    /// Wrapper for `glfwSetWindowContentScaleCallback`.
+    pub fn set_content_scale_polling(&mut self, should_poll: bool) {
+        set_window_callback!(self, should_poll, glfwSetWindowContentScaleCallback, window_content_scale_callback);
     }
 
     /// Wrapper for `glfwGetInputMode` called with `CURSOR`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1183,6 +1183,11 @@ impl Glfw {
     pub fn get_joystick(&self, id: JoystickId) -> Joystick {
         Joystick { id: id, glfw: self.clone() }
     }
+
+    /// Wrapper for `glfwRawMouseMotionSupported`.
+    pub fn supports_raw_motion(&self) -> bool {
+        unsafe { ffi::glfwRawMouseMotionSupported() == ffi::TRUE }
+    }
 }
 
 /// Wrapper for `glfwGetVersion`.
@@ -1323,6 +1328,16 @@ impl Monitor {
                     size:   ramp.red.len() as u32,
                 }
             );
+        }
+    }
+
+    /// Wrapper for `glfwGetMonitorContentScale`.
+    pub fn get_content_scale(&self) -> (f32, f32) {
+        unsafe {
+            let mut xscale = 0.0_f32;
+            let mut yscale = 0.0_f32;
+            ffi::glfwGetMonitorContentScale(self.ptr, &mut xscale, &mut yscale);
+            (xscale, yscale)
         }
     }
 }
@@ -1985,6 +2000,11 @@ impl Window {
         unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::RESIZABLE) == ffi::TRUE }
     }
 
+    /// Wrapper for `glfwSetWindowAttrib` called with `RESIZABLE`.
+    pub fn set_resizable(&mut self, resizable: bool) {
+        unsafe { ffi::glfwSetWindowAttrib(self.ptr, ffi::RESIZABLE, resizable as c_int) }
+    }
+
     /// Wrapper for `glfwGetWindowAttrib` called with `VISIBLE`.
     pub fn is_visible(&self) -> bool {
         unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::VISIBLE) == ffi::TRUE }
@@ -1993,6 +2013,51 @@ impl Window {
     /// Wrapper for `glfwGetWindowAttrib` called with `DECORATED`.
     pub fn is_decorated(&self) -> bool {
         unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::DECORATED) == ffi::TRUE }
+    }
+
+    /// Wrapper for `glfwSetWindowAttrib` called with `DECORATED`.
+    pub fn set_decorated(&mut self, decorated: bool) {
+        unsafe { ffi::glfwSetWindowAttrib(self.ptr, ffi::DECORATED, decorated as c_int) }
+    }
+
+    /// Wrapper for `glfwGetWindowAttrib` called with `AUTO_ICONIFY`.
+    pub fn is_auto_iconify(&self) -> bool {
+        unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::AUTO_ICONIFY) == ffi::TRUE }
+    }
+
+    /// Wrapper for `glfwSetWindowAttrib` called with `AUTO_ICONIFY`.
+    pub fn set_auto_iconify(&mut self, auto_iconify: bool) {
+        unsafe { ffi::glfwSetWindowAttrib(self.ptr, ffi::AUTO_ICONIFY, auto_iconify as c_int) }
+    }
+
+    /// Wrapper for `glfwGetWindowAttrib` called with `FLOATING`.
+    pub fn is_floating(&self) -> bool {
+        unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::FLOATING) == ffi::TRUE }
+    }
+
+    /// Wrapper for `glfwSetWindowAttrib` called with `FLOATING`.
+    pub fn set_floating(&mut self, floating: bool) {
+        unsafe { ffi::glfwSetWindowAttrib(self.ptr, ffi::FLOATING, floating as c_int) }
+    }
+
+    /// Wrapper for `glfwGetWindowAttrib` called with `TRANSPARENT_FRAMEBUFFER`.
+    pub fn is_framebuffer_transparent(&self) -> bool {
+        unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::TRANSPARENT_FRAMEBUFFER) == ffi::TRUE }
+    }
+
+    /// Wrapper for `glfwGetWindowAttrib` called with `FOCUS_ON_SHOW`.
+    pub fn is_focus_on_show(&self) -> bool {
+        unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::FOCUS_ON_SHOW) == ffi::TRUE }
+    }
+
+    /// Wrapper for `glfwSetWindowAttrib` called with `FOCUS_ON_SHOW`.
+    pub fn set_focus_on_show(&mut self, focus_on_show: bool) {
+        unsafe { ffi::glfwSetWindowAttrib(self.ptr, ffi::FOCUS_ON_SHOW, focus_on_show as c_int) }
+    }
+
+    /// Wrapper for `glfwGetWindowAttrib` called with `HOVERED`.
+    pub fn is_hovered(&self) -> bool {
+        unsafe { ffi::glfwGetWindowAttrib(self.ptr, ffi::HOVERED) == ffi::TRUE }
     }
 
     /// Wrapper for `glfwSetWindowPosCallback`.
@@ -2249,6 +2314,31 @@ impl Window {
     /// Wrapper for `glfwGetClipboardString`.
     pub fn get_clipboard_string(&self) -> Option<String> {
         unsafe { string_from_nullable_c_str(ffi::glfwGetClipboardString(self.ptr)) }
+    }
+
+    /// Wrapper for 'glfwGetWindowOpacity'.
+    pub fn get_opacity(&self) -> f32 {
+        unsafe { ffi::glfwGetWindowOpacity(self.ptr) }
+    }
+
+    /// Wrapper for 'glfwSetWindowOpacity'.
+    pub fn set_opacity(&mut self, opacity: f32) {
+        unsafe { ffi::glfwSetWindowOpacity(self.ptr, opacity) }
+    }
+
+    /// Wrapper for `glfwRequestWindowAttention`.
+    pub fn request_attention(&mut self) {
+        unsafe { ffi::glfwRequestWindowAttention(self.ptr) }
+    }
+
+    /// Wrapper for `glfwGetWindowContentScale`.
+    pub fn get_content_scale(&self) -> (f32, f32) {
+        unsafe {
+            let mut xscale = 0.0_f32;
+            let mut yscale = 0.0_f32;
+            ffi::glfwGetWindowContentScale(self.ptr, &mut xscale, &mut yscale);
+            (xscale, yscale)
+        }
     }
 
     /// Wrapper for `glfwGetWin32Window`


### PR DESCRIPTION
This PR updates the `glfw-rs` library to use glfw 3.3. As such, it is dependent on PistonDevelopers/glfw-sys#12 to be merged.

This is still a WIP, most new functions still have to be implemented.