### PR TITLE
Remove link libraries that are no longer required on linux

### DIFF
--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -37,12 +37,6 @@ extern {}
 
 #[cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly"))]
 #[link(name = "X11")]
-#[link(name = "GL")]
-#[link(name = "Xxf86vm")]
-#[link(name = "Xrandr")]
-#[link(name = "Xi")]
-#[link(name = "Xcursor")]
-#[link(name = "Xinerama")]
 extern {}
 
 #[cfg(target_os="macos")]


### PR DESCRIPTION
GLFW now loads these dynamically and they no longer need to be explicitly linked. 

https://www.glfw.org/docs/latest/compile_guide.html#compile_deps_x11

https://www.glfw.org/docs/latest/build_guide.html#build_link_pkgconfig

https://github.com/glfw/glfw/blob/51bb76c7c3de934b2dd3affcdc297a32e4817835/src/x11_init.c#L468

https://github.com/glfw/glfw/blob/master/src/glx_context.c#L253

```
$ PKG_CONFIG_PATH=. pkg-config --libs --static glfw3
-L/home/ci/git/glfw-rs/target/debug/build/glfw-sys-34282c5bfb8321b7/out/lib -lglfw3 -lrt -lm -ldl -lX11 -lpthread -lxcb -lXau -lXdmcp
```

