### PR TITLE
Add unbuffered event handling variants for `poll_events` and `wait_events`

### DIFF
--- a/examples/unbuffered_events.rs
+++ b/examples/unbuffered_events.rs
@@ -39,11 +39,15 @@ fn main() {
     });
 
     while !window.should_close() {
-        glfw.poll_events_unbuffered(|event| {
+        glfw.poll_events_unbuffered(|window_id, event| {
+            // Multiple windows may be identified by their `window_id`
+            assert_eq!(window.window_id(), window_id);
+
             // Intercept the close request and reset the flag
             if let (_, WindowEvent::Close) = event {
                 window.set_should_close(false);
             };
+
             // Forward the event to the render thread via the `events` receiver
             // to be processed asynchronously from the main event loop thread.
             // Returning `None` here would consume the event.

--- a/examples/unbuffered_events.rs
+++ b/examples/unbuffered_events.rs
@@ -1,0 +1,64 @@
+// Copyright 2013 The GLFW-RS Developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate glfw;
+
+use glfw::{Action, Context, Key, WindowEvent, RenderContext};
+
+fn main() {
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+
+    let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
+        .expect("Failed to create GLFW window.");
+
+    window.set_all_polling(true);
+    let mut render_context = window.render_context();
+
+    // Render asynchronously from the main event loop. This prevents a pause in rendering
+    // during some window interactions (e.g. resizing) on platforms like Windows.
+    let thread = std::thread::spawn(move || {
+        render_context.make_current();
+        while !render_context.should_close() {
+            for (_, event) in glfw::flush_messages(&events) {
+                handle_window_event(&mut render_context, event);
+            }
+            render_context.swap_buffers();
+        }
+    });
+
+    while !window.should_close() {
+        glfw.poll_events_unbuffered(|event| {
+            // Intercept the close request and reset the flag
+            if let (_, WindowEvent::Close) = event {
+                window.set_should_close(false);
+            };
+            // Forward the event to the render thread via the `events` receiver
+            // to be processed asynchronously from the main event loop thread.
+            // Returning `None` here would consume the event.
+            Some(event)
+        });
+    }
+
+    thread.join().unwrap();
+}
+
+fn handle_window_event(render_context: &mut RenderContext, event: glfw::WindowEvent) {
+    match event {
+        glfw::WindowEvent::Close | glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
+            render_context.set_should_close(true);
+        }
+        _ => {}
+    }
+}

--- a/examples/unbuffered_events.rs
+++ b/examples/unbuffered_events.rs
@@ -39,7 +39,7 @@ fn main() {
     });
 
     while !window.should_close() {
-        glfw.poll_events_unbuffered(|window_id, event| {
+        glfw.wait_events_unbuffered(|window_id, event| {
             // Multiple windows may be identified by their `window_id`
             assert_eq!(window.window_id(), window_id);
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -124,13 +124,71 @@ unsafe fn get_sender<'a>(window: &'a *mut ffi::GLFWwindow) -> &'a Sender<(f64, W
     mem::transmute(ffi::glfwGetWindowUserPointer(*window))
 }
 
+pub mod unbuffered {
+    use std::cell::RefCell;
+    use crate::WindowEvent;
+
+    type CallbackPtr = *mut std::ffi::c_void;
+    type HandlerFn = fn(event: (f64, WindowEvent), callback_ptr: CallbackPtr) -> Option<(f64, WindowEvent)>;
+
+    thread_local! {
+        static HANDLER: RefCell<Option<(HandlerFn, CallbackPtr)>> = RefCell::new(None);
+    }
+
+    pub struct UnsetHandlerGuard { _private: () }
+
+    impl Drop for UnsetHandlerGuard {
+        fn drop(&mut self) {
+            HANDLER.with(|ref_cell| {
+                *ref_cell.borrow_mut() = None;
+            })
+        }
+    }
+
+    pub unsafe fn handle(event: (f64, WindowEvent)) -> Option<(f64, WindowEvent)> {
+        HANDLER.with(|ref_cell| {
+            if let Some((handler, callback_ptr)) = *ref_cell.borrow() {
+                handler(event, callback_ptr)
+            } else {
+                Some(event)
+            }
+        })
+    }
+
+    pub unsafe fn set_handler<F>(mut callback: F) -> UnsetHandlerGuard
+    where
+        F: FnMut((f64, WindowEvent)) -> Option<(f64, WindowEvent)>
+    {
+        fn handler<F>(event: (f64, WindowEvent), callback_ptr: CallbackPtr) -> Option<(f64, WindowEvent)>
+        where
+            F: FnMut((f64, WindowEvent)) -> Option<(f64, WindowEvent)>
+        {
+            unsafe {
+                let callback: &mut F = &mut *(callback_ptr as *mut F);
+                callback(event)
+            }
+        }
+        HANDLER.with(|ref_cell| {
+            let callback_ptr = (&mut callback) as *mut F as CallbackPtr;
+            *ref_cell.borrow_mut() = Some((handler::<F>, callback_ptr));
+        });
+        UnsetHandlerGuard { _private: () }
+    }
+}
+
+
 // Note that this macro creates a static function pointer rather than a plain function.
 // This makes it more ergonomic to embed in an Option; see set_window_callback! in lib.rs
 macro_rules! window_callback (
     (fn $name:ident () => $event:ident) => (
         pub static $name: (extern "C" fn(window: *mut ffi::GLFWwindow)) = {
             extern "C" fn actual_callback(window: *mut ffi::GLFWwindow) {
-                unsafe { get_sender(&window).send((ffi::glfwGetTime() as f64, WindowEvent::$event)).unwrap();}
+                unsafe {
+                    let event = (ffi::glfwGetTime() as f64, WindowEvent::$event);
+                    if let Some(event) = unbuffered::handle(event) {
+                        get_sender(&window).send(event).unwrap();
+                    }
+                }
             }
             actual_callback
         };
@@ -138,7 +196,12 @@ macro_rules! window_callback (
     (fn $name:ident ($($ext_arg:ident: $ext_arg_ty:ty),*) => $event:ident($($arg_conv:expr),*)) => (
         pub static $name: (extern "C" fn(window: *mut ffi::GLFWwindow $(, $ext_arg: $ext_arg_ty)*)) = {
             extern "C" fn actual_callback(window: *mut ffi::GLFWwindow $(, $ext_arg: $ext_arg_ty)*) {
-                unsafe { get_sender(&window).send((ffi::glfwGetTime() as f64, WindowEvent::$event($($arg_conv),*))).unwrap(); }
+                unsafe {
+                    let event = (ffi::glfwGetTime() as f64, WindowEvent::$event($($arg_conv),*));
+                    if let Some(event) = unbuffered::handle(event) {
+                        get_sender(&window).send(event).unwrap();
+                    }
+                }
             }
             actual_callback
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,9 @@ pub use self::MouseButton::Button3 as MouseButtonMiddle;
 pub mod ffi;
 mod callbacks;
 
+/// Unique identifier for a `Window`.
+pub type WindowId = usize;
+
 /// Input actions.
 #[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -1077,7 +1080,10 @@ impl Glfw {
     /// `None` from the closure will drop the event.
     ///
     /// Wrapper for `glfwPollEvents`.
-    pub fn poll_events_unbuffered<F>(&mut self, f: F) where F: FnMut((f64, WindowEvent)) -> Option<(f64, WindowEvent)> {
+    pub fn poll_events_unbuffered<F>(&mut self, f: F)
+        where
+            F: FnMut(WindowId, (f64, WindowEvent)) -> Option<(f64, WindowEvent)>
+    {
         let _unset_handler_guard = unsafe {
             crate::callbacks::unbuffered::set_handler(f)
         };
@@ -1096,7 +1102,10 @@ impl Glfw {
     /// equivalent of `Glfw::poll_events_unbuffered`.
     ///
     /// Wrapper for `glfwWaitEvents`.
-    pub fn wait_events_unbuffered<F>(&mut self, f: F) where F: FnMut((f64, WindowEvent)) -> Option<(f64, WindowEvent)> {
+    pub fn wait_events_unbuffered<F>(&mut self, f: F)
+        where
+            F: FnMut(WindowId, (f64, WindowEvent)) -> Option<(f64, WindowEvent)>
+    {
         let _unset_handler_guard = unsafe {
             crate::callbacks::unbuffered::set_handler(f)
         };
@@ -1117,7 +1126,10 @@ impl Glfw {
     /// Timeout is specified in seconds.
     ///
     /// Wrapper for `glfwWaitEventsTimeout`.
-    pub fn wait_events_timeout_unbuffered<F>(&mut self, timeout: f64, f: F) where F: FnMut((f64, WindowEvent)) -> Option<(f64, WindowEvent)> {
+    pub fn wait_events_timeout_unbuffered<F>(&mut self, timeout: f64, f: F)
+        where
+            F: FnMut(WindowId, (f64, WindowEvent)) -> Option<(f64, WindowEvent)>
+    {
         let _unset_handler_guard = unsafe {
             crate::callbacks::unbuffered::set_handler(f)
         };
@@ -2535,6 +2547,11 @@ unsafe impl Send for RenderContext {}
 pub trait Context {
     /// Returns the pointer to the underlying `GLFWwindow`.
     fn window_ptr(&self) -> *mut ffi::GLFWwindow;
+
+    /// Returns the unique identifier for this window.
+    fn window_id(&self) -> WindowId {
+        self.window_ptr() as WindowId
+    }
 
     /// Swaps the front and back buffers of the window. If the swap interval is
     /// greater than zero, the GPU driver waits the specified number of screen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1663,9 +1663,8 @@ impl<'a> WindowMode<'a> {
     }
 }
 
-/// Key modifiers (e.g., Shift, Control, Alt, Super)
 bitflags! {
-    #[doc = "Key modifiers"]
+    #[doc = "Key modifiers (e.g., Shift, Control, Alt, Super)"]
     pub struct Modifiers: ::libc::c_int {
         const Shift       = ::ffi::MOD_SHIFT;
         const Control     = ::ffi::MOD_CONTROL;
@@ -2626,7 +2625,6 @@ impl GamepadAxis {
     }
 }
 
-/// Joystick hats.
 bitflags! {
     #[doc = "Joystick hats."]
     pub struct JoystickHats: ::libc::c_int {


### PR DESCRIPTION
* Unbuffered event polling allows for event interception and response on the main thread inside of the native GLFW callback. This can be especially helpful in multi-threaded scenarios when there's a desire to intercept the `Close` request. Another use-case is when `FramebufferSize` events should be responded to synchronously to enable smoother resizing (e.g. when resizing a Vulkan Swapchain on Windows).
* Added remaining thread-safe functions to Context and by extension RenderContext.