### PR TITLE
Remove context check for get_instance_proc_address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1789,12 +1789,6 @@ impl Window {
     /// Wrapper for `glfwGetInstanceProcAddress`
     #[cfg(feature = "vulkan")]
     pub fn get_instance_proc_address(&mut self, instance: VkInstance, procname: &str) -> VkProc {
-        //TODO: Determine if setting this context as current is required? It doesn't seem to be required for vkCreateInstance,
-        //TODO: but it might be needed for other pointers.
-        if self.ptr != unsafe { ffi::glfwGetCurrentContext() } {
-            self.make_current();
-        }
-
         self.glfw.get_instance_proc_address_raw(instance, procname)
     }
 


### PR DESCRIPTION
Looks like this was missed from #398. Attempting to set the context with vulkan results in a GLFW error (because the context client is set to GLFW_NO_API).

https://github.com/glfw/glfw/blob/master/src/context.c#L613