### PR TITLE
Fix warnings from nightly 1.38.0

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -32,7 +32,7 @@ macro_rules! callback (
         let ext_set = $ext_set:expr;
         fn callback($($ext_arg:ident: $ext_arg_ty:ty),*) $call:expr
     ) => (
-        thread_local!(static CALLBACK_KEY: RefCell<Option<Box<Object<Args> + 'static>>> = RefCell::new(None));
+        thread_local!(static CALLBACK_KEY: RefCell<Option<Box<dyn Object<Args> + 'static>>> = RefCell::new(None));
 
         type Args = ($($arg_ty),*,);
 
@@ -47,7 +47,7 @@ macro_rules! callback (
         }
 
         pub fn set<UserData: 'static>(f: ::$Callback<UserData>) {
-            let mut boxed_cb = Some(Box::new(f) as Box<Object<Args> + 'static>);
+            let mut boxed_cb = Some(Box::new(f) as Box<dyn Object<Args> + 'static>);
             CALLBACK_KEY.with(|cb| {
                 *cb.borrow_mut() = boxed_cb.take();
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,8 +701,8 @@ pub fn init<UserData: 'static>(mut callback: Option<ErrorCallback<UserData>>) ->
             ffi::glfwTerminate();
         }
     }
-    use std::sync::{Once, ONCE_INIT};
-    static mut INIT: Once = ONCE_INIT;
+    use std::sync::Once;
+    static mut INIT: Once = Once::new();
     let mut result = Err(InitError::AlreadyInitialized);
     unsafe {
         INIT.call_once(|| {
@@ -2595,7 +2595,7 @@ impl Context for RenderContext {
 }
 
 /// Wrapper for `glfwMakeContextCurrent`.
-pub fn make_context_current(context: Option<&Context>) {
+pub fn make_context_current(context: Option<&dyn Context>) {
     match context {
         Some(ctx) => unsafe { ffi::glfwMakeContextCurrent(ctx.window_ptr()) },
         None      => unsafe { ffi::glfwMakeContextCurrent(ptr::null_mut()) },


### PR DESCRIPTION
`ONCE_INIT` has been replaced with `Once::new()`, and trait objects should be marked `dyn`.