### PR TITLE
implement Drop for Glfw for safe termination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,3 @@ image = "^0.22"
 all = ["image", "vulkan"]
 default = ["glfw-sys"]
 vulkan = ["vk-sys"]
-terminate_manually = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,7 +618,7 @@ pub struct Glfw;
 /// An error that might be returned when `glfw::init` is called.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum InitError {
-    /// Deprecated. not occurs.
+    /// Deprecated. Does not occur.
     AlreadyInitialized,
     /// An internal error occurred when trying to initialize the library.
     Internal,


### PR DESCRIPTION
Now `struct Glfw` impl `Drop` For safe GLFW termination.

It occurs following interface changes:
- Glfw is now not impl `Copy`
- Joystick is now not impl `Copy`

You should use explicit clone() when copy these marker objects.

And `manually_termination` feature is dropped. Because we can `glfwTerminate()` by Dropping Glfw marker object.

FYI: This is discussed on https://github.com/PistonDevelopers/glfw-rs/pull/428