### PR TITLE
Update to raw-window-handle 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bitflags = "1.0.0"
 libc = "0.2"
 log = "0.4"
 semver = "0.9"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/examples/raw_window_handle.rs
+++ b/examples/raw_window_handle.rs
@@ -35,7 +35,7 @@ fn main() {
         },
 
         #[cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly"))]
-        RawWindowHandle::X11(handle) => {
+        RawWindowHandle::Xlib(handle) => {
             println!("raw handle: {:?}", handle)
         },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2622,16 +2622,16 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
 
     #[cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly"))]
     {
-        use raw_window_handle::unix::X11Handle;
+        use raw_window_handle::unix::XlibHandle;
         let (window, display) = unsafe {
             let window = ffi::glfwGetX11Window(context.window_ptr());
             let display = ffi::glfwGetX11Display();
             (window as std::os::raw::c_ulong, display)
         };
-        RawWindowHandle::X11(X11Handle {
+        RawWindowHandle::Xlib(XlibHandle {
             window,
             display,
-            ..X11Handle::empty()
+            ..XlibHandle::empty()
         })
     }
 


### PR DESCRIPTION
The `raw-window-handle` crate has seen some breaking changes which prevent this crate from being used elsewhere in the ecosystem right now (i.e. with the latest version of `gfx-hal`).

This PR updates the dependency to 0.3 in the crate manifest and replaces usages of `RawWindowHandle::X11` and `X11Handle` with `RawWindowHandle::Xlib` and `XlibHandle` respectively. The code is otherwise identical except for these name changes.
 