### PR TITLE
Add `hinstance` field to `WindowsHandle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ raw-window-handle = "0.3"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3", features = ["libloaderapi"] }
+
 [dependencies.glfw-sys]
 optional = true
 version = "^3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2611,11 +2611,14 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
     #[cfg(target_family = "windows")]
     {
         use raw_window_handle::windows::WindowsHandle;
-        let hwnd = unsafe {
-            ffi::glfwGetWin32Window(context.window_ptr())
+        let (hwnd, hinstance) = unsafe {
+            let hwnd = ffi::glfwGetWin32Window(context.window_ptr());
+            let hinstance = winapi::um::libloaderapi::GetModuleHandleW(std::ptr::null());
+            (hwnd, hinstance as _)
         };
         RawWindowHandle::Windows(WindowsHandle {
             hwnd,
+            hinstance,
             ..WindowsHandle::empty()
         })
     }


### PR DESCRIPTION
This field previously defaulted to a null pointer because of `..WindowsHandle::empty()`. It is described here: https://github.com/rust-windowing/raw-window-handle/issues/2. Let me know what you think.