### PR TITLE
Prevent direct instantiation of Glfw leading to panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,6 +636,7 @@ static REF_COUNT_FOR_GLFW: AtomicUsize = AtomicUsize::new(0);
 /// only be initialized on the main platform thread. Whilst this might make
 /// performing some operations harder, this is to ensure thread safety is enforced
 /// statically.
+#[non_exhaustive]
 pub struct Glfw;
 
 /// An error that might be returned when `glfw::init` is called.


### PR DESCRIPTION
Just to preface. I didn't find any notes about minimum supported Rust version, so I just want to point-out that `#[non_exhaustive]` was included in [stable release 1.40.0](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html#[non_exhaustive]-structs,-enums,-and-variants) ([RFC](https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md#unit-structs)).

-----

The change is simple, I added `#[non_exhaustive]` to `Glfw`.

```rust
#[non_exhaustive]
pub struct Glfw;
```

Which prevents instantiation of `Glfw`, like this:

```
let glfw = Glfw;
```

Producing the following error instead:

```
error[E0423]: expected value, found struct `Glfw`                                                   
  --> app\src\app.rs:59:32
   |
59 |                     let glfw = Glfw;
   |                                ^^^^ did you mean `Glfw { /* fields */ }`?

error: aborting due to previous error                                                               
```

Without it, it's possible to do the following:

```rust
let glfw = Glfw;
println!("{}", glfw.get_time());
```

When that `Glfw` is dropped, then the internal `REF_COUNT_FOR_GLFW` is decremented, while it wasn't incremented in the first place. Then when the "actual" `glfw` instance is used, it results in a panic.

```
thread 'main' panicked at 'GLFW Error: The GLFW library is not initialized'
```

If there is multiple `Glfw`s alive throughout the application's lifetime, which have been properly cloned, then the panic is "postponed" and tracking down a rogue instantiation of `Glfw` becomes hard.

-----

Ignoring minimum Rust version, then this pull request introduces *no* breaking changes. *Unless someone is doing the thing they shouldn't be doing.*