### PR TITLE
Fixed drop order causing panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1963,7 +1963,6 @@ impl<'a, Message: 'static + Send> Iterator for FlushedMessages<'a, Message> {
 /// A struct that wraps a `*GLFWwindow` handle.
 pub struct Window {
     ptr: *mut ffi::GLFWwindow,
-    pub glfw: Glfw,
     pub is_shared: bool,
     /// A `Sender` that can be cloned out to child `RenderContext`s.
     drop_sender: Option<Sender<()>>,
@@ -1974,6 +1973,7 @@ pub struct Window {
     /// This is here to allow owning the current Cursor object instead
     /// of forcing the user to take care of its lifetime.
     current_cursor: Option<Cursor>,
+    pub glfw: Glfw,
 }
 
 macro_rules! set_window_callback {


### PR DESCRIPTION
Another small change, which fixes a panic.

For years I've had a `Window` wrapper around `glfw::Window`, with some various added metadata, which boils down to:

```rust
pub struct Window {
    window: glfw::Window,
}
```

Today, I just started using `set_cursor`, e.g.

```rust
window.set_cursor(Some(Cursor::standard(StandardCursor::Hand)));
```

But when closing the program, then the program panicked:

```
thread 'main' panicked at 'GLFW Error: The GLFW library is not initialized', 
C:\Users\Vallentin\Desktop\glfw-rs\src\lib.rs:432:5
```

I realized that since I didn't keep a `Glfw` around, that when `glfw::Window` is being dropped, it first drops its `Glfw` causing GLFW to get terminated. Then after it attempts to destroy the `Cursor`, which then triggers the "GLFW not initialized".

-----

A temporary workaround for anybody that has this problem is to call `set_cursor(None)` prior to the `glfw::Window` being dropped.

```rust
window.set_cursor(None);
```