### PR TITLE
Fix update_gamepad_mappings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1414,9 +1414,9 @@ impl Glfw {
     /// `true` if successful, or `false` if an error occurred.
     pub fn update_gamepad_mappings(&self, mappings: &str) -> bool {
         unsafe {
-            let c_str = CString::new(mappings.as_bytes());
-            let ptr = c_str.unwrap().as_bytes_with_nul().as_ptr() as *const c_char;
-            ffi::glfwUpdateGamepadMappings(ptr) == ffi::TRUE
+            with_c_str(mappings, |mappings| {
+                ffi::glfwUpdateGamepadMappings(mappings) == ffi::TRUE
+            })
         }
     }
 }


### PR DESCRIPTION
Hello, 

the current implementation of `update_gamepad_mappings` causes a segmentation fault on my system when called with a string containing the entire `gamecontrollerdb.txt` file. I believe the reason for that is that `ptr` is dangling.

I replaced the code using `with_c_str`, which does not cause a segmentation fault anymore and seems to be the proper tool for that.