### PR TITLE
Remove libc dependency in favor of std::os::raw aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.39.1"
 
 [dependencies]
 bitflags = "1.0.0"
-libc = "0.2"
 log = "0.4"
 semver = "0.9"
 raw-window-handle = "0.3"

--- a/examples/defaults.rs
+++ b/examples/defaults.rs
@@ -81,8 +81,6 @@ fn main() {
 }
 
 mod gl {
-    extern crate libc;
-
     #[cfg(target_os = "macos")]
     #[link(name = "OpenGL", kind = "framework")]
     extern "C" {}
@@ -91,8 +89,8 @@ mod gl {
     #[link(name = "GL")]
     extern "C" {}
 
-    pub type GLenum = libc::c_uint;
-    pub type GLint = libc::c_int;
+    pub type GLenum = std::os::raw::c_uint;
+    pub type GLint = std::os::raw::c_int;
 
     pub static RED_BITS: GLenum = 0x0D52;
     pub static GREEN_BITS: GLenum = 0x0D53;

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -15,7 +15,7 @@
 
 //! Private callback support functions.
 
-use libc::{c_char, c_double, c_int, c_uint};
+use std::os::raw::{c_char, c_double, c_int, c_uint};
 use std::ffi::CStr;
 use std::mem;
 use std::path::PathBuf;
@@ -73,7 +73,7 @@ macro_rules! callback (
 );
 
 pub mod error {
-    use libc::{c_char, c_int};
+    use std::os::raw::{c_char, c_int};
     use std::cell::RefCell;
     use std::mem;
 
@@ -88,7 +88,7 @@ pub mod error {
 }
 
 pub mod monitor {
-    use libc::c_int;
+    use std::os::raw::c_int;
     use std::cell::RefCell;
     use std::mem;
 
@@ -106,7 +106,7 @@ pub mod monitor {
 }
 
 pub mod joystick {
-    use libc::c_int;
+    use std::os::raw::c_int;
     use std::cell::RefCell;
     use std::mem;
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -18,8 +18,8 @@
 
 #![allow(bad_style)] // yeah yeah, but it's ffi
 
-use libc::{c_char, c_double, c_float, c_int, c_ulonglong};
-use libc::{c_uchar, c_uint, c_ushort, c_void};
+use std::os::raw::{c_char, c_double, c_float, c_int, c_ulonglong};
+use std::os::raw::{c_uchar, c_uint, c_ushort, c_void};
 
 #[cfg(feature = "vulkan")]
 use vk_sys::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@
 
 // TODO: Document differences between GLFW and glfw-rs
 
-extern crate libc;
 extern crate semver;
 #[cfg(feature = "vulkan")]
 extern crate vk_sys;
@@ -86,9 +85,9 @@ extern crate raw_window_handle;
 extern crate objc;
 
 #[cfg(feature = "vulkan")]
-use libc::c_uint;
-use libc::{c_char, c_double, c_float, c_int};
-use libc::{c_uchar, c_ushort, c_void};
+use std::os::raw::c_uint;
+use std::os::raw::{c_char, c_double, c_float, c_int};
+use std::os::raw::{c_uchar, c_ushort, c_void};
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use semver::Version;
 use std::error;
@@ -1882,7 +1881,7 @@ impl<'a> WindowMode<'a> {
 
 bitflags! {
     #[doc = "Key modifiers (e.g., Shift, Control, Alt, Super)"]
-    pub struct Modifiers: ::libc::c_int {
+    pub struct Modifiers: ::std::os::raw::c_int {
         const Shift       = ::ffi::MOD_SHIFT;
         const Control     = ::ffi::MOD_CONTROL;
         const Alt         = ::ffi::MOD_ALT;
@@ -3109,7 +3108,7 @@ impl GamepadAxis {
 
 bitflags! {
     #[doc = "Joystick hats."]
-    pub struct JoystickHats: ::libc::c_int {
+    pub struct JoystickHats: ::std::os::raw::c_int {
         const Centered = ::ffi::HAT_CENTERED;
         const Up       = ::ffi::HAT_UP;
         const Right    = ::ffi::HAT_RIGHT;


### PR DESCRIPTION
The libc dependency is unnecessary since these aliases are already found in the standard library.