### PR TITLE
Make features to all to make rust-analyzer happy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ image = "^0.23"
 
 [features]
 all = ["image", "vulkan"]
-default = ["glfw-sys"]
+default = ["all", "glfw-sys"]
 vulkan = ["vk-sys"]


### PR DESCRIPTION
I am using vscode, I realized that everytime when I open the editor with rust-analyzer, examples will show errors because they depend features