### PR TITLE
Make log optional to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0.0"
-log = "0.4"
 semver = "0.9"
 raw-window-handle = "0.3"
 
@@ -29,6 +28,10 @@ version = "^3.3"
 optional = true
 version = "^0.23"
 
+[dependencies.log]
+optional = true
+log = "0.4"
+
 [dependencies.vk-sys]
 optional = true
 version = "^0.4"
@@ -36,8 +39,9 @@ version = "^0.4"
 [dev-dependencies]
 vk-sys = "^0.4"
 image = "^0.23"
+log = "0.4"
 
 [features]
-all = ["image", "vulkan"]
+all = ["image", "vulkan", "log"]
 default = ["glfw-sys"]
 vulkan = ["vk-sys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 
 #[cfg(feature = "vulkan")]
 extern crate vk_sys;
+#[cfg(feature="log")]
 #[macro_use]
 extern crate log;
 #[macro_use]
@@ -442,10 +443,18 @@ pub static FAIL_ON_ERRORS: Option<ErrorCallback<()>> = Some(Callback {
     data: (),
 });
 
+#[cfg(feature="log")]
 /// The function to be used with the `LOG_ERRORS` callback.
 pub fn log_errors(_: Error, description: String, _: &()) {
     error!("GLFW Error: {}", description);
 }
+
+#[cfg(not(feature="log"))]
+/// The function to be used with the `LOG_ERRORS` callback.
+pub fn log_errors(_: Error, description: String, _: &()) {
+    eprintln!("GLFW Error: {}", description);
+}
+
 
 /// A callback that logs each error as it is encountered without triggering a
 /// task failure.
@@ -2860,6 +2869,7 @@ impl Drop for Window {
         drop(self.drop_sender.take());
 
         // Check if all senders from the child `RenderContext`s have hung up.
+        #[cfg(feature="log")]
         if self.drop_receiver.try_recv() != Err(std::sync::mpsc::TryRecvError::Disconnected) {
             debug!("Attempted to drop a Window before the `RenderContext` was dropped.");
             debug!("Blocking until the `RenderContext` was dropped.");


### PR DESCRIPTION
I have noticed that removing log crate, reduces the binary size:
with all features disabled using the current crate:
```
[dependencies]
glfw = { version = "0.41.0", features = [], default-features = false }
```
the size of multiwindow example: 355K

With the new version with log as optional the size goes down to 331K
