### PR TITLE
Remove dependency on semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0.0"
-semver = "0.9"
 raw-window-handle = "0.4.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ extern crate image;
 extern crate objc;
 
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-use semver::Version;
+
 use std::error;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -129,6 +129,13 @@ pub mod ffi;
 
 /// Unique identifier for a `Window`.
 pub type WindowId = usize;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Version {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
 
 /// Input actions.
 #[repr(i32)]
@@ -1412,8 +1419,6 @@ pub fn get_version() -> Version {
             major: major as u64,
             minor: minor as u64,
             patch: patch as u64,
-            pre: Vec::new(),
-            build: Vec::new(),
         }
     }
 }
@@ -2264,8 +2269,6 @@ impl Window {
                 major: ffi::glfwGetWindowAttrib(self.ptr, ffi::CONTEXT_VERSION_MAJOR) as u64,
                 minor: ffi::glfwGetWindowAttrib(self.ptr, ffi::CONTEXT_VERSION_MINOR) as u64,
                 patch: ffi::glfwGetWindowAttrib(self.ptr, ffi::CONTEXT_REVISION) as u64,
-                pre: Vec::new(),
-                build: Vec::new(),
             }
         }
     }


### PR DESCRIPTION
We were depending on an old version and none of the parsing or version comparison methods were even utilized.