### PR TITLE
Adds wayland support to glfw-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,7 @@ log = "0.4"
 all = ["image", "vulkan", "log"]
 default = ["glfw-sys"]
 vulkan = ["vk-sys"]
+wayland = ["glfw-sys/wayland"]
+
+[patch.crates-io]
+glfw-sys = { git = "https://github.com/maximveligan/glfw-sys-wayland" }

--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -35,7 +35,17 @@ extern "C" {}
 #[link(name = "shell32")]
 extern "C" {}
 
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"),
+    feature = "wayland"
+))]
+#[link(name = "wayland-client")]
+extern "C" {}
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"),
+    not(feature = "wayland")
+))]
 #[link(name = "X11")]
 extern "C" {}
 


### PR DESCRIPTION
Adds support to glfw-rs to link against wayland-client instead of just X11, using a "wayland" feature flag. Relies on https://github.com/PistonDevelopers/glfw-sys/pull/19
Resolves https://github.com/PistonDevelopers/glfw-rs/issues/485