### PR TITLE
Remove deprecated vk-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ version = "^0.24.1"
 optional = true
 version = "0.4"
 
-[dependencies.vk-sys]
+[dependencies.ash]
 optional = true
-version = "^0.4"
+version = "0.37.2"
 
 [dev-dependencies]
 log = "0.4"
@@ -42,5 +42,5 @@ log = "0.4"
 [features]
 all = ["image", "vulkan", "log", "wayland"]
 default = ["glfw-sys"]
-vulkan = ["vk-sys"]
+vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -22,10 +22,7 @@ use std::os::raw::{c_char, c_double, c_float, c_int, c_ulonglong};
 use std::os::raw::{c_uchar, c_uint, c_ushort, c_void};
 
 #[cfg(feature = "vulkan")]
-use vk_sys::{
-    AllocationCallbacks as VkAllocationCallbacks, Instance as VkInstance,
-    PhysicalDevice as VkPhysicalDevice, Result as VkResult, SurfaceKHR as VkSurfaceKHR,
-};
+use ash::vk;
 
 mod link;
 
@@ -658,20 +655,20 @@ extern "C" {
     #[cfg(feature = "vulkan")]
     pub fn glfwGetRequiredInstanceExtensions(count: *mut c_uint) -> *const *const c_char;
     #[cfg(feature = "vulkan")]
-    pub fn glfwGetInstanceProcAddress(instance: VkInstance, procname: *const c_char) -> GLFWvkproc;
+    pub fn glfwGetInstanceProcAddress(instance: vk::Instance, procname: *const c_char) -> GLFWvkproc;
     #[cfg(feature = "vulkan")]
     pub fn glfwGetPhysicalDevicePresentationSupport(
-        instance: VkInstance,
-        device: VkPhysicalDevice,
+        instance: vk::Instance,
+        device: vk::PhysicalDevice,
         queuefamily: c_uint,
     ) -> c_int;
     #[cfg(feature = "vulkan")]
     pub fn glfwCreateWindowSurface(
-        instance: VkInstance,
+        instance: vk::Instance,
         window: *mut GLFWwindow,
-        allocator: *const VkAllocationCallbacks,
-        surface: *mut VkSurfaceKHR,
-    ) -> VkResult;
+        allocator: *const vk::AllocationCallbacks,
+        surface: *mut vk::SurfaceKHR,
+    ) -> vk::Result;
 
     // native APIs
 
@@ -689,7 +686,7 @@ extern "C" {
     pub fn glfwGetX11Window(window: *mut GLFWwindow) -> *mut c_void;
     #[cfg(all(any(target_os = "linux", target_os = "freebsd"), not(feature = "wayland")))]
     pub fn glfwGetX11Display() -> *mut c_void;
-    
+
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     pub fn glfwGetGLXContext(window: *mut GLFWwindow) -> *mut c_void;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,6 @@
 
 // TODO: Document differences between GLFW and glfw-rs
 
-#[cfg(feature = "vulkan")]
-extern crate vk_sys;
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
@@ -112,10 +110,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 
 #[cfg(feature = "vulkan")]
-use vk_sys::{
-    self as vk, AllocationCallbacks as VkAllocationCallbacks, Instance as VkInstance,
-    PhysicalDevice as VkPhysicalDevice, Result as VkResult, SurfaceKHR as VkSurfaceKHR,
-};
+use ash::vk;
 
 /// Alias to `MouseButton1`, supplied for improved clarity.
 pub use self::MouseButton::Button1 as MouseButtonLeft;
@@ -1343,7 +1338,7 @@ impl Glfw {
     ///
     /// Wrapper for `glfwGetInstanceProcAddress`
     #[cfg(feature = "vulkan")]
-    pub fn get_instance_proc_address_raw(&self, instance: VkInstance, procname: &str) -> VkProc {
+    pub fn get_instance_proc_address_raw(&self, instance: vk::Instance, procname: &str) -> VkProc {
         with_c_str(procname, |procname| unsafe {
             ffi::glfwGetInstanceProcAddress(instance, procname)
         })
@@ -1356,8 +1351,8 @@ impl Glfw {
     #[cfg(feature = "vulkan")]
     pub fn get_physical_device_presentation_support_raw(
         &self,
-        instance: VkInstance,
-        device: VkPhysicalDevice,
+        instance: vk::Instance,
+        device: vk::PhysicalDevice,
         queue_family: u32,
     ) -> bool {
         vk::TRUE
@@ -1989,7 +1984,7 @@ impl Window {
     ///
     /// Wrapper for `glfwGetInstanceProcAddress`
     #[cfg(feature = "vulkan")]
-    pub fn get_instance_proc_address(&mut self, instance: VkInstance, procname: &str) -> VkProc {
+    pub fn get_instance_proc_address(&mut self, instance: vk::Instance, procname: &str) -> VkProc {
         self.glfw.get_instance_proc_address_raw(instance, procname)
     }
 
@@ -2000,8 +1995,8 @@ impl Window {
     #[cfg(feature = "vulkan")]
     pub fn get_physical_device_presentation_support(
         &self,
-        instance: VkInstance,
-        device: VkPhysicalDevice,
+        instance: vk::Instance,
+        device: vk::PhysicalDevice,
         queue_family: u32,
     ) -> bool {
         self.glfw
@@ -2012,10 +2007,10 @@ impl Window {
     #[cfg(feature = "vulkan")]
     pub fn create_window_surface(
         &self,
-        instance: VkInstance,
-        allocator: *const VkAllocationCallbacks,
-        surface: *mut VkSurfaceKHR,
-    ) -> VkResult {
+        instance: vk::Instance,
+        allocator: *const vk::AllocationCallbacks,
+        surface: *mut vk::SurfaceKHR,
+    ) -> vk::Result {
         unsafe { ffi::glfwCreateWindowSurface(instance, self.ptr, allocator, surface) }
     }
     /// Wrapper for `glfwCreateWindow`.


### PR DESCRIPTION
This commit removes the deprecated `vk-sys` crate in favor of the `ash` crate, supplied by [ash-rs/ash](https://github.com/ash-rs/ash).

Note `ash` does not strictly practice semver, and breaking changes can occur between patches, so a direct version dependency was made.

This closes #496