### PR TITLE
platform gate window hint string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,12 +934,15 @@ impl Glfw {
         }
 
         #[inline(always)]
+        #[allow(unused)]
         unsafe fn string_hint(hint: c_int, value: Option<String>) {
             let value = if let Some(value) = &value {
                 value.as_str()
             } else {
                 ""
             };
+            // glfwWindowHintString is not provided by emscripten. maybe this should be fixed in emscripten?
+            #[cfg(not(target_arch = "wasm32"))]
             with_c_str(value, |value| ffi::glfwWindowHintString(hint, value))
         }
 


### PR DESCRIPTION
emscripten doesn't provide the `windowHintString` fn, so we will get link errors if we use `Glfw::window_hint` fn. on C/C++, windowHint and windowHintString are separate functions, so you just don't use the string version. but in this library both are combined into one function, so even if i don't use the string version of hints, it will still be pulled in by the window_hint fn.

the only relevant string hints are x11/cocoa related, so they should not affect anything on emscripten at all. 

Ideally, emscripten will provide a no-op windowHintString, but contributing to emscripten is much harder :) 