### PR TITLE
Removed &mut self from post_empty_event fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,7 +1227,7 @@ impl Glfw {
     /// If no windows exist, this function returns immediately.
     ///
     /// Wrapper for `glfwPostEmptyEvent`.
-    pub fn post_empty_event(&mut self) {
+    pub fn post_empty_event() {
         unsafe {
             ffi::glfwPostEmptyEvent();
         }


### PR DESCRIPTION
Fixes #523

I commented on both #523 and #473. In #473 `Glfw` was made non-send, which rendered `post_empty_event()` useless, as it would no longer be possible to pass a clone of `Glfw` to a thread, to call `glfw.post_empty_event()`. Alternatively requiring doing the following instead:

```rust
unsafe {
    glfw::ffi::glfwPostEmptyEvent();
}
```

However, as far as I know and can tell from reading the C source, there is no need to require `&mut self`. It should be safe to call `Glfw::post_empty_event()` before GLFW has been initialized as well as after GLFW has been terminated. As far as I can tell, is that calling it before GLFW has been initialized, it might not trigger any event. Though that sounds like an edge case to me.

In my opinion, it's better to have it usable. Maybe adding a note about calling `post_empty_event()` before having initialized GLFW.

I have verified this behavior on both Windows 10 (Win32) and macOS (Cocoa).
