### PR TITLE
Fixes #517

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1477,6 +1477,25 @@ impl std::fmt::Debug for Monitor {
 }
 
 impl Monitor {
+
+    /// Wrapper for `glfwGetPrimaryMonitor`.
+    pub fn from_primary() -> Self {
+        unsafe {
+            Self {
+                ptr: ffi::glfwGetPrimaryMonitor()
+            }
+        }
+    }
+
+    /// Wrapper for `glfwGetWindowMonitor`.
+    pub fn from_window(window: &Window) -> Self {
+        unsafe {
+            Self {
+                ptr: ffi::glfwGetWindowMonitor(window.ptr)
+            }
+        }
+    }
+
     /// Wrapper for `glfwGetMonitorPos`.
     pub fn get_pos(&self) -> (i32, i32) {
         unsafe {


### PR DESCRIPTION
Added wrappers for `glfwGetPrimaryMonitor` and `glfwGetWindowMonitor` to the `Monitor` struct. This fixes #517 