### PR TITLE
Stabilized window callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,7 @@ version = "0.37.2"
 log = "0.4"
 
 [features]
-all = ["image", "vulkan", "log", "wayland", "glfw-callbacks"]
+all = ["image", "vulkan", "log", "wayland"]
 default = ["glfw-sys"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
-glfw-callbacks = []


### PR DESCRIPTION
Window callbacks were previously behind a feature gate because the implementation i wrote was inherently unsafe. This was because the user could move the window object out of the `Box` after creating the window, and this would break the new callback code that requires the window pointer to never change. It just occurred to me to wrap the `Box<Window>` inside a struct `PWindow` with its own `Deref` and `DerefMut` implementations, preventing the user from taking the window out of the wrapper. This effectively stabilizes the new callback implementation so i removed the "glfw-callbacks" feature from Cargo.toml. Let me know if there is any problem, even tho i tested it and it seems to work.