### PR TITLE
Upgrade GLFW for Wgpu safe surface creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.56"
 
 [dependencies]
 bitflags = "1.0.0"
-raw-window-handle = "0.5.0"
+raw-window-handle = "0.6.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
@@ -44,3 +44,4 @@ all = ["image", "vulkan", "log", "wayland"]
 default = ["glfw-sys"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ rust-version = "1.56"
 
 [dependencies]
 bitflags = "1.0.0"
-raw-window-handle = "0.6.0"
+# would like one to enable when raw-window-handle-v0-6 is not enabled, but have not figured out how
+raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0"}
+raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
@@ -44,4 +46,4 @@ all = ["image", "vulkan", "log", "wayland"]
 default = ["glfw-sys"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
-
+raw-window-handle-v0-6 = ["dep:raw-window-handle-0-6"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ version = "0.37.2"
 log = "0.4"
 
 [features]
-all = ["image", "vulkan", "log", "wayland"]
-default = ["glfw-sys"]
+all = ["image", "vulkan", "log", "wayland", "raw-window-handle-v0-6"]
+default = ["glfw-sys", "raw-window-handle-v0-6"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
 raw-window-handle-v0-6 = ["dep:raw-window-handle-0-6"]

--- a/examples/raw_window_handle.rs
+++ b/examples/raw_window_handle.rs
@@ -14,10 +14,17 @@
 // limitations under the License.
 
 extern crate glfw;
-extern crate raw_window_handle;
+#[cfg(feature = "raw-window-handle-v0-6")]
+extern crate raw_window_handle_0_6 as raw_window_handle;
+
+#[cfg(not(feature = "raw-window-handle-v0-6"))]
+extern crate raw_window_handle_0_5 as raw_window_handle;
 
 use glfw::{Action, Context, Key};
+#[cfg(feature = "raw-window-handle-v0-6")]
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+#[cfg(not(feature = "raw-window-handle-v0-6"))]
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 fn main() {
     let mut glfw = glfw::init_no_callbacks().unwrap();
@@ -28,8 +35,12 @@ fn main() {
 
     window.set_key_polling(true);
     window.make_current();
+    #[cfg(feature = "raw-window-handle-v0-6")]
+    let raw = window.window_handle().unwrap().as_raw();
+    #[cfg(not(feature = "raw-window-handle-v0-6"))]
+    let raw = window.raw_window_handle();
 
-    match window.window_handle().unwrap().as_raw() {
+    match raw {
         RawWindowHandle::Win32(handle) => println!("raw handle: {:?}", handle),
         RawWindowHandle::Xlib(handle) => println!("raw handle: {:?}", handle),
         RawWindowHandle::Wayland(handle) => println!("raw handle: {:?}", handle),

--- a/examples/raw_window_handle.rs
+++ b/examples/raw_window_handle.rs
@@ -17,7 +17,7 @@ extern crate glfw;
 extern crate raw_window_handle;
 
 use glfw::{Action, Context, Key};
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 fn main() {
     let mut glfw = glfw::init_no_callbacks().unwrap();
@@ -29,7 +29,7 @@ fn main() {
     window.set_key_polling(true);
     window.make_current();
 
-    match window.raw_window_handle() {
+    match window.window_handle().unwrap().as_raw() {
         RawWindowHandle::Win32(handle) => println!("raw handle: {:?}", handle),
         RawWindowHandle::Xlib(handle) => println!("raw handle: {:?}", handle),
         RawWindowHandle::Wayland(handle) => println!("raw handle: {:?}", handle),

--- a/examples/render_task.rs
+++ b/examples/render_task.rs
@@ -53,7 +53,7 @@ fn main() {
     let _ = render_task_done;
 }
 
-fn render(mut context: glfw::RenderContext, finish: Receiver<()>) {
+fn render(mut context: glfw::PRenderContext, finish: Receiver<()>) {
     context.make_current();
     loop {
         // Check if the rendering should stop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3398,6 +3398,7 @@ impl Drop for Window {
 }
 
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct PRenderContext(Box<RenderContext>);
 
 impl Deref for PRenderContext {
@@ -3452,12 +3453,14 @@ impl PRenderContext {
 unsafe impl Send for PRenderContext {}
 unsafe impl Sync for PRenderContext {}
 
+#[cfg(feature = "raw-window-handle-v0-6")]
 impl HasWindowHandle for PRenderContext {
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         self.0.window_handle()
     }
 }
 
+#[cfg(feature = "raw-window-handle-v0-6")]
 impl HasDisplayHandle for PRenderContext {
     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         self.0.display_handle()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,10 @@ impl DerefMut for PWindow {
     }
 }
 
+unsafe impl Send for PWindow {}
+
+unsafe impl Sync for PWindow {}
+
 // these are technically already implemented, but somehow this fixed a error in wgpu
 #[cfg(feature = "raw-window-handle-v0-6")]
 impl HasWindowHandle for PWindow {
@@ -3411,42 +3415,6 @@ impl Deref for PRenderContext {
 impl DerefMut for PRenderContext {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.deref_mut()
-    }
-}
-
-impl PRenderContext {
-
-    /// Wrapper function, please refer to [`Window::get_proc_address`]
-    pub fn get_proc_address(&mut self, procname: &str) -> GLProc {
-        self.0.get_proc_address(procname)
-    }
-
-    /// Wrapper function, please refer to [`Window::get_instance_proc_address`]
-    #[cfg(feature = "vulkan")]
-    pub fn get_instance_proc_address(&mut self, instance: vk::Instance, procname: &str) -> VkProc {
-        self.0.get_instance_proc_address(instance, procname)
-    }
-
-    /// Wrapper function, please refer to [`Window::get_physical_device_presentation_support`]
-    #[cfg(feature = "vulkan")]
-    pub fn get_physical_device_presentation_support(
-        &self,
-        instance: vk::Instance,
-        device: vk::PhysicalDevice,
-        queue_family: u32,
-    ) -> bool {
-        self.0.get_physical_device_presentation_support(instance, device, queue_family)
-    }
-
-    /// Wrapper function, please refer to [`Window::create_window_surface`]
-    #[cfg(feature = "vulkan")]
-    pub fn create_window_surface(
-        &self,
-        instance: vk::Instance,
-        allocator: *const vk::AllocationCallbacks,
-        surface: *mut vk::SurfaceKHR,
-    ) -> vk::Result {
-        self.0.create_window_surface(instance, allocator, surface)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ extern crate log;
 extern crate bitflags;
 #[cfg(feature = "image")]
 extern crate image;
-#[cfg(all(target_os = "macos"))]
+#[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;
 
@@ -3646,13 +3646,12 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
         use std::ptr::NonNull;
         use raw_window_handle::AppKitWindowHandle;
         let ns_view = unsafe {
+            let ns_window: *mut objc::runtime::Object = ffi::glfwGetCocoaWindow(context.window_ptr()) as *mut _;
             let ns_view: *mut objc::runtime::Object = objc::msg_send![ns_window, contentView];
             assert_ne!(ns_view, std::ptr::null_mut());
-            (
-                ns_view as *mut std::ffi::c_void
-            )
+            ns_view as *mut std::ffi::c_void
         };
-        let mut handle = AppKitWindowHandle::new(NonNull::new(ns_view).unwrap());
+        let handle = AppKitWindowHandle::new(NonNull::new(ns_view).unwrap());
         RawWindowHandle::AppKit(handle)
     }
     #[cfg(target_os = "emscripten")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3590,8 +3590,6 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
     }
     #[cfg(target_os = "macos")]
     {
-        // until I can test
-        compile_error!("macos support for raw-window-handle 0.6 is not yet tested");
         use std::ptr::NonNull;
         use raw_window_handle::AppKitWindowHandle;
         let ns_view = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,21 @@ impl DerefMut for PWindow {
     }
 }
 
+// these are technically already implemented, but somehow this fixed a error in wgpu
+#[cfg(feature = "raw-window-handle-v0-6")]
+impl HasWindowHandle for PWindow {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        self.0.window_handle()
+    }
+}
+
+#[cfg(feature = "raw-window-handle-v0-6")]
+impl HasDisplayHandle for PWindow {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        self.0.display_handle()
+    }
+}
+
 /// Unique identifier for a `Window`.
 pub type WindowId = usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3622,15 +3622,17 @@ fn raw_display_handle() -> RawDisplayHandle {
     #[cfg(all(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"), not(feature = "wayland")))]
     {
         use raw_window_handle::XlibDisplayHandle;
-        let mut handle = XlibDisplayHandle::empty();
-        handle.display = unsafe { ffi::glfwGetX11Display() };
+        use std::ptr::NonNull;
+        let display = NonNull::new(unsafe { ffi::glfwGetX11Display() });
+        let handle = XlibDisplayHandle::new(display, 0);
         RawDisplayHandle::Xlib(handle)
     }
     #[cfg(all(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"), feature = "wayland"))]
     {
         use raw_window_handle::WaylandDisplayHandle;
-        let mut handle = WaylandDisplayHandle::empty();
-        handle.display = unsafe { ffi::glfwGetWaylandDisplay() };
+        use std::ptr::NonNull;
+        let display = NonNull::new(unsafe { ffi::glfwGetWaylandDisplay() });
+        let handle = WaylandDisplayHandle::new(display, 0);
         RawDisplayHandle::Wayland(handle)
     }
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
This adds the necessary features to support safe surface creation (gfx-rs/wgpu#4597) by upgrading raw-window-handle to v0.6.0, and adding a boxed render context (named PRenderContext), as this makes the new raw-window-handle default (which is different from v0.5) this is a **breaking change**.

closes #562 

### Testing
Currently tested on Windows with both wgpu and the raw-window-handle example and tested on Linux (xlib handle) with raw_window_handle example

**todo:**
- [x] more testing on Linux (wgpu)
- [x] testing on Macos
- Maybe testing on Emscriptem? (not sure I need this as emsciptem is unchanged)