### PR TITLE
Update README.md to fix issue #558

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+    let mut glfw = glfw::init(glfw::fail_on_errors).unwrap();
 
     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");


### PR DESCRIPTION
The code example has an issue where the string "FAIL_ON_ERRORS" on line six is apparently falsely capitalized.