### PR TITLE
Use `objc2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0"}
 raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "0.2"
+objc2 = "0.5.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi"] }


### PR DESCRIPTION
[`objc2`](https://github.com/madsmtm/objc2) is a replacement for `objc` that contains a bunch of safety and performance improvements, including `Id` and `msg_send_id!` which automatically upholds memory management rules.

Specifically for glfw-rs, this is likely ever so slightly faster, as the message sending can be done without needing to put the view into an autorelease pool.

Note: We could've used `objc2-app-kit` to avoid the manual `msg_send_id!` here, but the extra dependency seemed excessive.