### PR TITLE
fix: Expect that wayland surface is non null

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3638,7 +3638,7 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
         use raw_window_handle::WaylandWindowHandle;
         use std::ptr::NonNull;
         let surface = unsafe { ffi::glfwGetWaylandWindow(context.window_ptr()) };
-        let mut handle = WaylandWindowHandle::new(NonNull::new(surface));
+        let mut handle = WaylandWindowHandle::new(NonNull::new(surface).expect("wayland window surface is null"));
         RawWindowHandle::Wayland(handle)
     }
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
`NonNull::new` returns an option. Assert that we do get a window surface as WaylandWindowHandle expects a NonNull. 