### PR TITLE
Feat: Optional raw window handle 0.5 dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ rust-version = "1.56"
 
 [dependencies]
 bitflags = "1.0.0"
-# would like one to enable when raw-window-handle-v0-6 is not enabled, but have not figured out how
-raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0"}
+raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0", optional = true }
 raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -47,3 +46,4 @@ default = ["glfw-sys", "raw-window-handle-v0-6"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
 raw-window-handle-v0-6 = ["dep:raw-window-handle-0-6"]
+raw-window-handle-v0-5 = ["dep:raw-window-handle-0-5"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ log = "0.4"
 [features]
 all = ["image", "vulkan", "log", "wayland", "raw-window-handle-v0-6"]
 default = ["glfw-sys", "raw-window-handle-v0-6"]
+with-window-handle-v0-5 = ["glfw-sys", "raw-window-handle-v0-5"]
 vulkan = ["ash"]
 wayland = ["glfw-sys/wayland"]
 raw-window-handle-v0-6 = ["dep:raw-window-handle-0-6"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ version = "*"
 default-features = false
 ~~~
 
+### Raw window handle 0.5.0 compatibility
+
+By default, `glfw-rs` uses raw-window-handle at v0.6.0. If your project is depending on `glfw-rs`
+with raw-window-handle v0.5.0, then use this line in your Cargo.toml:
+~~~
+glfw = { version = 0.56.0 , default-features = false, features = ["with-window-handle-0-5"] }
+~~~
+
 ## Support
 
 Contact `bjz` on irc.mozilla.org [#rust](http://mibbit.com/?server=irc.mozilla.org&channel=%23rust)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ default-features = false
 By default, `glfw-rs` uses raw-window-handle at v0.6.0. If your project is depending on `glfw-rs`
 with raw-window-handle v0.5.0, then use this line in your Cargo.toml:
 ~~~
-glfw = { version = 0.56.0 , default-features = false, features = ["with-window-handle-0-5"] }
+glfw = { version = 0.56.0 , default-features = false, features = ["with-window-handle-v0-5"] }
 ~~~
 
 ## Support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,12 +233,12 @@ extern crate image;
 #[cfg(feature = "raw-window-handle-v0-6")]
 extern crate raw_window_handle_0_6 as raw_window_handle;
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 extern crate raw_window_handle_0_5 as raw_window_handle;
 
 use std::collections::VecDeque;
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 use raw_window_handle::{HasRawWindowHandle, HasRawDisplayHandle};
 
 #[cfg(feature = "raw-window-handle-v0-6")]
@@ -3584,28 +3584,28 @@ impl HasDisplayHandle for RenderContext {
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 unsafe impl HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> RawWindowHandle {
         raw_window_handle(self)
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 unsafe impl HasRawWindowHandle for RenderContext {
     fn raw_window_handle(&self) -> RawWindowHandle {
         raw_window_handle(self)
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 unsafe impl HasRawDisplayHandle for Window {
     fn raw_display_handle(&self) -> RawDisplayHandle {
         raw_display_handle()
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 unsafe impl HasRawDisplayHandle for RenderContext {
     fn raw_display_handle(&self) -> RawDisplayHandle {
         raw_display_handle()
@@ -3700,7 +3700,7 @@ fn raw_display_handle() -> RawDisplayHandle {
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
     #[cfg(target_family = "windows")]
     {
@@ -3758,7 +3758,7 @@ fn raw_window_handle<C: Context>(context: &C) -> RawWindowHandle {
     }
 }
 
-#[cfg(not(feature = "raw-window-handle-v0-6"))]
+#[cfg(feature = "raw-window-handle-v0-5")]
 fn raw_display_handle() -> RawDisplayHandle {
     #[cfg(target_family = "windows")]
     {


### PR DESCRIPTION
Cargo docs seems to only point on making a new crate flag for this option. <br>
Semantics of this right now is we have raw-window-handle v0.6 as default. To use v0.5, one has to turn off defaults and use a similar to default flag but with raw-window-handle v0.5 as dep.