### PR TITLE
Update ash version and fix examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.4"
 
 [dependencies.ash]
 optional = true
-version = "0.37.2"
+version = "0.38"
 
 [dev-dependencies]
 log = "0.4"

--- a/examples/vulkan.rs
+++ b/examples/vulkan.rs
@@ -73,8 +73,8 @@ unsafe fn create_instance(entry: &ash::Entry, extensions: &Vec<String>) -> ash::
     let extension_pointers: Vec<*const i8> = extensions.iter().map(|ext| ext.as_ptr()).collect();
     //This is literally the bare minimum required to create a blank instance
     //You'll want to fill in this with real data yourself
-    let info: vk::InstanceCreateInfoBuilder =
-        vk::InstanceCreateInfo::builder().enabled_extension_names(&extension_pointers);
+    let info: vk::InstanceCreateInfo =
+        vk::InstanceCreateInfo::default().enabled_extension_names(&extension_pointers);
 
     unsafe {
         entry

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -666,7 +666,7 @@ extern "C" {
     pub fn glfwCreateWindowSurface(
         instance: vk::Instance,
         window: *mut GLFWwindow,
-        allocator: *const vk::AllocationCallbacks,
+        allocator: *const vk::AllocationCallbacks<'_>,
         surface: *mut vk::SurfaceKHR,
     ) -> vk::Result;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2490,7 +2490,7 @@ impl Window {
     pub fn create_window_surface(
         &self,
         instance: vk::Instance,
-        allocator: *const vk::AllocationCallbacks,
+        allocator: *const vk::AllocationCallbacks<'_>,
         surface: *mut vk::SurfaceKHR,
     ) -> vk::Result {
         unsafe { ffi::glfwCreateWindowSurface(instance, self.ptr, allocator, surface) }
@@ -3480,7 +3480,7 @@ impl RenderContext {
     pub fn create_window_surface(
         &self,
         instance: vk::Instance,
-        allocator: *const vk::AllocationCallbacks,
+        allocator: *const vk::AllocationCallbacks<'_>,
         surface: *mut vk::SurfaceKHR,
     ) -> vk::Result {
         unsafe { ffi::glfwCreateWindowSurface(instance, self.ptr, allocator, surface) }


### PR DESCRIPTION
- Updated ash dependency from 0.37.2 -> 0.38
  - The only required library change was `vk::AllocationCallbacks`, which now needs a lifetime
- Fixed the Vulkan example to reflect the new ash syntax.