### PR TITLE
Added mouse button aliases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,6 +554,13 @@ pub enum MouseButton {
 }
 
 impl MouseButton {
+    /// Alias to `MouseButton1`, supplied for improved clarity.
+    pub const Left: Self = MouseButton::Button1;
+    /// Alias to `MouseButton2`, supplied for improved clarity.
+    pub const Right: Self = MouseButton::Button2;
+    /// Alias to `MouseButton3`, supplied for improved clarity.
+    pub const Middle: Self = MouseButton::Button3;
+
     /// Converts from `i32`.
     pub fn from_i32(n: i32) -> Option<MouseButton> {
         if (0..=ffi::MOUSE_BUTTON_LAST).contains(&n) {


### PR DESCRIPTION
This might be a personal preference, but I usually have `MouseButton` imported, which would make it easier to do `MouseButton::Left`, compared to importing `glfw::MouseButtonLeft`.

Additionally, this is also _sliiiightly_ "safer" to use, as if someone forgets to import `glfw::MouseButtonLeft`, then matching on a `MouseButton` and having `MouseButtonLeft` in a match arm, that would only produce a warning. While forgetting to import `MouseButton` when using `MouseButton::Left`, would cause an error.

-----

I can refactor some of the `MouseButtonLeft` (and friends) doc references, to instead point to `MouseButton::Left` (and friends), if that is desired?
