### PR TITLE
Make GLFW error conversion total and handle GLFW 3.4 codes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,6 +28,6 @@ jobs:
               run: cargo run --example=version --features=prebuilt-libs
 
             - name: Src Builds
-              run: |       
-                cargo run --example=version --features=src-build
-                cargo run --example=version --features=src-build,static-link
+              run: |
+                cargo run --example=version --no-default-features --features=all,src-build
+                cargo run --example=version --no-default-features --features=all,src-build,dynamic-link

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -57,13 +57,12 @@ macro_rules! callback (
 
 pub mod error {
     use std::cell::RefCell;
-    use std::mem;
     use std::os::raw::{c_char, c_int};
 
     callback!(
         args -> (crate::Error, String),
         glfw -> glfwSetErrorCallback(error: c_int, description: *const c_char),
-        convert_args -> (mem::transmute(error), crate::string_from_c_str(description))
+        convert_args -> (crate::Error::from_raw(error), crate::string_from_c_str(description))
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,57 @@ pub enum Error {
     PlatformError = ffi::GLFW_PLATFORM_ERROR,
     FormatUnavailable = ffi::GLFW_FORMAT_UNAVAILABLE,
     NoWindowContext = ffi::GLFW_NO_WINDOW_CONTEXT,
+    CursorUnavailable = ffi::GLFW_CURSOR_UNAVAILABLE,
+    FeatureUnavailable = ffi::GLFW_FEATURE_UNAVAILABLE,
+    FeatureUnimplemented = ffi::GLFW_FEATURE_UNIMPLEMENTED,
+    PlatformUnavailable = ffi::GLFW_PLATFORM_UNAVAILABLE,
+    Unknown(c_int),
+}
+
+impl Error {
+    /// Converts a raw GLFW error code without assuming it is known by this crate.
+    pub const fn from_raw(raw: c_int) -> Self {
+        match raw {
+            ffi::GLFW_NO_ERROR => Self::NoError,
+            ffi::GLFW_NOT_INITIALIZED => Self::NotInitialized,
+            ffi::GLFW_NO_CURRENT_CONTEXT => Self::NoCurrentContext,
+            ffi::GLFW_INVALID_ENUM => Self::InvalidEnum,
+            ffi::GLFW_INVALID_VALUE => Self::InvalidValue,
+            ffi::GLFW_OUT_OF_MEMORY => Self::OutOfMemory,
+            ffi::GLFW_API_UNAVAILABLE => Self::ApiUnavailable,
+            ffi::GLFW_VERSION_UNAVAILABLE => Self::VersionUnavailable,
+            ffi::GLFW_PLATFORM_ERROR => Self::PlatformError,
+            ffi::GLFW_FORMAT_UNAVAILABLE => Self::FormatUnavailable,
+            ffi::GLFW_NO_WINDOW_CONTEXT => Self::NoWindowContext,
+            ffi::GLFW_CURSOR_UNAVAILABLE => Self::CursorUnavailable,
+            ffi::GLFW_FEATURE_UNAVAILABLE => Self::FeatureUnavailable,
+            ffi::GLFW_FEATURE_UNIMPLEMENTED => Self::FeatureUnimplemented,
+            ffi::GLFW_PLATFORM_UNAVAILABLE => Self::PlatformUnavailable,
+            raw => Self::Unknown(raw),
+        }
+    }
+
+    /// Returns the raw GLFW error code represented by this value.
+    pub const fn as_raw(self) -> c_int {
+        match self {
+            Self::NoError => ffi::GLFW_NO_ERROR,
+            Self::NotInitialized => ffi::GLFW_NOT_INITIALIZED,
+            Self::NoCurrentContext => ffi::GLFW_NO_CURRENT_CONTEXT,
+            Self::InvalidEnum => ffi::GLFW_INVALID_ENUM,
+            Self::InvalidValue => ffi::GLFW_INVALID_VALUE,
+            Self::OutOfMemory => ffi::GLFW_OUT_OF_MEMORY,
+            Self::ApiUnavailable => ffi::GLFW_API_UNAVAILABLE,
+            Self::VersionUnavailable => ffi::GLFW_VERSION_UNAVAILABLE,
+            Self::PlatformError => ffi::GLFW_PLATFORM_ERROR,
+            Self::FormatUnavailable => ffi::GLFW_FORMAT_UNAVAILABLE,
+            Self::NoWindowContext => ffi::GLFW_NO_WINDOW_CONTEXT,
+            Self::CursorUnavailable => ffi::GLFW_CURSOR_UNAVAILABLE,
+            Self::FeatureUnavailable => ffi::GLFW_FEATURE_UNAVAILABLE,
+            Self::FeatureUnimplemented => ffi::GLFW_FEATURE_UNIMPLEMENTED,
+            Self::PlatformUnavailable => ffi::GLFW_PLATFORM_UNAVAILABLE,
+            Self::Unknown(raw) => raw,
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -622,6 +673,11 @@ impl fmt::Display for Error {
             Error::PlatformError => "PlatformError",
             Error::FormatUnavailable => "FormatUnavailable",
             Error::NoWindowContext => "NoWindowContext",
+            Error::CursorUnavailable => "CursorUnavailable",
+            Error::FeatureUnavailable => "FeatureUnavailable",
+            Error::FeatureUnimplemented => "FeatureUnimplemented",
+            Error::PlatformUnavailable => "PlatformUnavailable",
+            Error::Unknown(raw) => return write!(f, "Unknown({raw})"),
         };
 
         f.write_str(description)
@@ -1975,15 +2031,20 @@ impl WindowCallbacks {
 
 /// Wrapper for `glfwGetError`.
 pub fn get_error() -> Error {
-    unsafe { mem::transmute(ffi::glfwGetError(null_mut())) }
+    Error::from_raw(unsafe { ffi::glfwGetError(null_mut()) })
 }
 
 /// Wrapper for `glfwGetError`.
 pub fn get_error_string() -> (Error, String) {
     unsafe {
         let mut description: *const c_char = null();
-        let error: Error = mem::transmute(ffi::glfwGetError(&mut description));
-        (error, string_from_c_str(description))
+        let error = Error::from_raw(ffi::glfwGetError(&mut description));
+        let description = if description.is_null() {
+            String::new()
+        } else {
+            string_from_c_str(description)
+        };
+        (error, description)
     }
 }
 

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,40 @@
+use glfw::{ffi, Error};
+
+#[test]
+fn all_glfw_3_4_error_codes_round_trip() {
+    let known = [
+        (ffi::GLFW_NO_ERROR, Error::NoError),
+        (ffi::GLFW_NOT_INITIALIZED, Error::NotInitialized),
+        (ffi::GLFW_NO_CURRENT_CONTEXT, Error::NoCurrentContext),
+        (ffi::GLFW_INVALID_ENUM, Error::InvalidEnum),
+        (ffi::GLFW_INVALID_VALUE, Error::InvalidValue),
+        (ffi::GLFW_OUT_OF_MEMORY, Error::OutOfMemory),
+        (ffi::GLFW_API_UNAVAILABLE, Error::ApiUnavailable),
+        (ffi::GLFW_VERSION_UNAVAILABLE, Error::VersionUnavailable),
+        (ffi::GLFW_PLATFORM_ERROR, Error::PlatformError),
+        (ffi::GLFW_FORMAT_UNAVAILABLE, Error::FormatUnavailable),
+        (ffi::GLFW_NO_WINDOW_CONTEXT, Error::NoWindowContext),
+        (ffi::GLFW_CURSOR_UNAVAILABLE, Error::CursorUnavailable),
+        (ffi::GLFW_FEATURE_UNAVAILABLE, Error::FeatureUnavailable),
+        (ffi::GLFW_FEATURE_UNIMPLEMENTED, Error::FeatureUnimplemented),
+        (ffi::GLFW_PLATFORM_UNAVAILABLE, Error::PlatformUnavailable),
+    ];
+
+    for (raw, expected) in known {
+        assert_eq!(Error::from_raw(raw), expected);
+        assert_eq!(expected.as_raw(), raw);
+    }
+}
+
+#[test]
+fn unknown_error_codes_preserve_the_raw_value() {
+    for raw in [i32::MIN, -1, 1, 0x0001_0000, 0x0001_000f, i32::MAX] {
+        assert_eq!(Error::from_raw(raw), Error::Unknown(raw));
+        assert_eq!(Error::from_raw(raw).as_raw(), raw);
+    }
+}
+
+#[test]
+fn unknown_error_display_includes_the_raw_value() {
+    assert_eq!(Error::Unknown(-42).to_string(), "Unknown(-42)");
+}


### PR DESCRIPTION
## Summary

- Add the GLFW 3.4 error variants missing from `glfw::Error`:
  - `CursorUnavailable`
  - `FeatureUnavailable`
  - `FeatureUnimplemented`
  - `PlatformUnavailable`
- Add `Error::Unknown(c_int)` for forward-compatible handling of unknown codes.
- Add total `Error::from_raw` and `Error::as_raw` conversions.
- Replace error-code `transmute` calls in the error callback, `get_error`, and `get_error_string`.
- Handle the null description returned by `glfwGetError` when no error is present.
- Update the stale CI `static-link` invocation to test the current static and dynamic linking features.

## Motivation

GLFW 3.4 introduced additional non-fatal error codes, but `glfw::Error` did not include them. Raw error codes were converted with `mem::transmute`, which requires every input to be a valid enum discriminant.

For example, a platform-dependent operation such as setting a window position under Wayland can report `GLFW_FEATURE_UNAVAILABLE`. Converting that code into the previous `Error` enum could cause undefined behavior before the user callback received the error.

The new invariant is:

```text
known GLFW code   -> matching Error variant
unknown GLFW code -> Error::Unknown(raw_code)
```

Every `c_int` now produces a valid Rust value.

## API impact

`glfw::Error` gains four GLFW 3.4 variants, the `Unknown(c_int)` fallback, and the `from_raw` / `as_raw` methods. Exhaustive downstream matches will need to handle the new variants.

No other GLFW enum conversion is changed by this pull request.

## CI adjustment

`static-link` is no longer a feature in `glfw`/`glfw-sys` 8.0.0. Static linking is now the default and dynamic linking is selected through `dynamic-link`.

The source-build job now tests both configurations explicitly with default features disabled.

## Validation

- All 15 GLFW 3.4 error codes round-trip through `from_raw` and `as_raw`.
- Unknown positive and negative values, including both `i32` bounds, preserve their raw value.
- Unknown error formatting includes the raw code.
- `cargo test --test error` passes.
- `cargo test --test error --features serde` passes.
- The GitHub Actions Linux, macOS, and Windows matrix passes.